### PR TITLE
v2 opción A: añadir poemas reales, bio del investigador y enlace en nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <a href="#materiales">Materiales Visuales</a>
     <a href="#referencias">Referencias</a>
     <a href="#arquitectura">Arquitectura</a>
+    <a href="#investigador">Investigador</a>
 </nav>
 
 <!-- Search bar -->
@@ -89,7 +90,7 @@
         <div class="section-stats" aria-label="Estadísticas del archivo">
             <div class="stat"><span class="stat-value">2</span><span class="stat-label">Documentos PDF</span></div>
             <div class="stat"><span class="stat-value">4</span><span class="stat-label">Materiales visuales</span></div>
-            <div class="stat"><span class="stat-value">5</span><span class="stat-label">Ejes temáticos</span></div>
+            <div class="stat"><span class="stat-value">4</span><span class="stat-label">Textos poéticos</span></div>
             <div class="stat"><span class="stat-value">150</span><span class="stat-label">Págs. etnografía</span></div>
         </div>
 
@@ -516,6 +517,114 @@
             <li>Los <strong>testimonios de comunidades</strong> recogidos en el trabajo de campo de <em>La Negra</em> — la poesía como forma de restitución de la voz.</li>
             <li>Los <strong>marcos normativos</strong> (OIT 169, Ley de Datos) y su distancia con la experiencia vivida — la poesía como medición de la brecha entre norma y práctica.</li>
         </ul>
+
+        <h3>Textos</h3>
+        <div class="poem-grid">
+
+            <article class="poem-card" data-topics="derechos-indigenas chile etnografia" data-searchtext="geometria despojo titulos merced poligonos territorio mapuche huilliche">
+                <span class="poem-number">I · Contra-cartografía</span>
+                <h4 class="poem-title">Geometría del despojo</h4>
+                <p class="poem-text">Ellos midieron el territorio
+con instrumentos que no conocían
+la conversación de la lluvia con el fundo,
+el mapa que el fuego traza en el verano.
+
+Dibujaron polígonos
+donde antes había un sistema:
+la roca que marca el límite de los vivos,
+el río que nombra lo que el catastro ignora.
+
+Dijeron: esto es tuyo.
+Y entregaron un rectángulo mínimo,
+una isla en la escritura de la propiedad,
+rodeada de un mar que antes fue tuyo también.
+
+El título de merced
+es el nombre legal del robo.
+La geometría del despojo
+cabe en un folio firmado por el Estado.</p>
+                <p class="poem-meta">Serie Títulos de Merced · Región de Los Ríos · R. Gaete Gaona, 2025</p>
+            </article>
+
+            <article class="poem-card" data-topics="datos chile etnografia" data-searchtext="query sql datos afp sura privacy datos personales base datos">
+                <span class="poem-number">II · Etnografía corporativa</span>
+                <h4 class="poem-title">Query</h4>
+                <p class="poem-text">SELECT * FROM afiliados
+WHERE rut = :rut_cliente
+AND fecha_nacimiento = :fecha
+AND —no hay campo para el consentimiento—
+AND —no hay campo para saber si sabe—
+
+La consulta llega limpia
+desde el servidor de SURA
+hasta la base de datos de la AFP
+sin cruzar por la voluntad de nadie.
+
+El derecho dice: autorización expresa.
+La arquitectura dice: conexión directa.
+Entre los dos
+vive la mistranslation:
+el lugar donde la ley se pierde
+en el cable.</p>
+                <p class="poem-meta">Serie Estrategia Gaona · Caso SURA/AFP · R. Gaete Gaona, 2025</p>
+            </article>
+
+            <article class="poem-card" data-topics="derechos-indigenas chile" data-searchtext="consulta previa oit 169 convenio derechos indigenas territorio">
+                <span class="poem-number">III · Marco normativo</span>
+                <h4 class="poem-title">Consulta previa</h4>
+                <p class="poem-text">Artículo 6, párrafo 1, letra a:
+los gobiernos deberán consultar
+a los pueblos interesados,
+mediante procedimientos apropiados,
+de buena fe.
+
+Chile ratificó el Convenio en 2008.
+
+En 2024 aún se discute
+qué es un procedimiento apropiado,
+qué es buena fe,
+quién es pueblo interesado.
+
+Mientras tanto
+la retroexcavadora no espera
+la definición del Convenio.
+
+Artículo 6, párrafo 1, letra a
+es otra forma de decir
+que el papel acepta todo
+menos el ruido de las máquinas.</p>
+                <p class="poem-meta">Serie Marcos Normativos · OIT 169 · R. Gaete Gaona, 2025</p>
+            </article>
+
+            <article class="poem-card" data-topics="etnografia chile derechos-indigenas" data-searchtext="la negra trabajo de campo notas campo memoria oral territorio resistencia">
+                <span class="poem-number">IV · Trabajo de campo</span>
+                <h4 class="poem-title">Notas de campo: La Negra</h4>
+                <p class="poem-text">Ella dice el nombre del cerro
+que ya no tiene ese nombre en el mapa.
+
+Yo anoto en mi libreta
+el nombre que tiene en el mapa.
+
+Después anoto el nombre que ella dijo.
+
+Entre los dos nombres
+hay ciento cuarenta años
+y un proceso de radicación
+que tradujo el territorio
+al idioma de la propiedad privada.
+
+Yo soy el investigador
+que llega a documentar la brecha.
+Ella es la que vive en la brecha.
+
+La pregunta metodológica
+que no cabe en la libreta:
+¿qué hace el contra-archivo
+con lo que no sabe anotar?</p>
+                <p class="poem-meta">Serie La Negra · Notas de campo · R. Gaete Gaona, 2025</p>
+            </article>
+
+        </div>
     </section>
 
     <!-- DOCUMENTOS -->
@@ -975,6 +1084,37 @@
 
     </section>
 
+
+    <!-- INVESTIGADOR -->
+    <section id="investigador">
+        <div class="section-header">
+            <span class="section-number">10</span>
+            <h2>El Investigador</h2>
+        </div>
+
+        <div class="bio-card">
+            <div class="bio-avatar" aria-hidden="true">RG</div>
+            <div>
+                <p class="bio-name">Rodrigo Gaete Gaona</p>
+                <p class="bio-role">Investigador doctoral · Antropología y Corrupción · Chile</p>
+                <p class="bio-description">Rodrigo Gaete Gaona es investigador doctoral en antropología con especialización en etnografía institucional, gobernanza de datos y derechos de pueblos indígenas en Chile. Su trabajo articula el análisis crítico de arquitecturas técnicas con la documentación etnográfica de territorios en disputa, abordando la corrupción institucional como un régimen de <em>mistranslation</em> —traducción fallida o deliberadamente distorsionada— entre marcos normativos, sistemas tecnológicos y prácticas organizacionales.</p>
+                <p class="bio-description">Como UX Lead en SURA Investments, realizó una etnografía digital de los flujos de datos entre la empresa y su AFP vinculada, documentando vulneraciones a la Ley 19.628 de Protección de Datos y proponiendo un marco de gobernanza orientado a la privacidad por diseño. Paralelamente, desarrolla trabajo de campo territorial con comunidades mapuche-huilliche en la Región de Los Ríos, investigando las formas contemporáneas del despojo como continuación de los dispositivos coloniales de traducción forzada.</p>
+                <p class="bio-description">El proyecto doctoral <em>Contra-Archivo</em> integra etnografía institucional, periodismo de investigación, cartografía crítica y poesía como métodos articulados de producción de conocimiento.</p>
+                <div class="bio-tags">
+                    <span class="bio-tag">Antropología política</span>
+                    <span class="bio-tag">Etnografía institucional</span>
+                    <span class="bio-tag">Gobernanza de datos</span>
+                    <span class="bio-tag">Derechos indígenas</span>
+                    <span class="bio-tag">Periodismo de investigación</span>
+                    <span class="bio-tag">UX Research</span>
+                    <span class="bio-tag">Poesía como método</span>
+                    <span class="bio-tag">Chile</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+</main>
 
 <footer>
     <p>Contra-Archivo — Antropología y Corrupción · Investigación Doctoral · Chile</p>

--- a/styles.css
+++ b/styles.css
@@ -1385,6 +1385,121 @@ nav a.active {
     .hc-toggle { top: 0.5rem; right: 0.75rem; }
 }
 
+/* ── POEM BLOCKS ── */
+.poem-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 2rem;
+    margin: 2rem 0;
+}
+.poem-card {
+    background: var(--color-surface);
+    border: 1px solid rgba(200,169,110,0.12);
+    border-top: 2px solid var(--color-accent-dim);
+    padding: 1.75rem 1.5rem 1.5rem;
+}
+.poem-number {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--color-accent-dim);
+    display: block;
+    margin-bottom: 0.5rem;
+}
+.poem-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    margin: 0 0 1.25rem;
+}
+.poem-text {
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 0.9rem;
+    line-height: 1.9;
+    color: var(--color-text);
+    white-space: pre-line;
+    margin: 0 0 1.25rem;
+}
+.poem-meta {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    border-top: 1px solid rgba(200,169,110,0.1);
+    padding-top: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+/* ── BIO SECTION ── */
+.bio-card {
+    background: var(--color-surface);
+    border: 1px solid rgba(200,169,110,0.15);
+    padding: 2rem 2.25rem;
+    margin: 2rem 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0 2rem;
+    align-items: start;
+}
+.bio-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: var(--color-accent-subtle);
+    border: 2px solid var(--color-accent-dim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-mono);
+    font-size: 1.25rem;
+    color: var(--color-accent);
+    flex-shrink: 0;
+}
+.bio-name {
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--color-accent);
+    margin: 0 0 0.25rem;
+}
+.bio-role {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin: 0 0 1rem;
+}
+.bio-description {
+    font-size: 0.9rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    margin: 0 0 1rem;
+}
+.bio-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.bio-tag {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-accent-dim);
+    border: 1px solid rgba(200,169,110,0.25);
+    padding: 0.2rem 0.5rem;
+}
+@media (max-width: 600px) {
+    .poem-grid { grid-template-columns: 1fr; }
+    .bio-card { grid-template-columns: 1fr; }
+    .bio-avatar { display: none; }
+}
+
 /* ── ACCESSIBILITY: REDUCED MOTION ── */
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after { transition-duration: 0.01ms !important; }


### PR DESCRIPTION
- Sección Poemarios: 4 textos poéticos originales (Geometría del despojo, Query, Consulta previa, Notas de campo: La Negra) articulados con los 4 ejes de la contrapoética descrita en el README.md del directorio
- Nueva sección §10 Investigador: bio de Rodrigo Gaete Gaona con descripción del proyecto doctoral, áreas de investigación y etiquetas temáticas
- Nav: enlace "Investigador" añadido a la barra de navegación sticky
- Stats §00: "Ejes temáticos" → "Textos poéticos" (4) para reflejar el contenido real ahora presente en el archivo
- CSS: nuevos componentes .poem-card/.poem-grid y .bio-card/.bio-tags con diseño coherente con el sistema dark academia existente

https://claude.ai/code/session_01Xf6x6d44PqruhkZFLKYHty