### PR TITLE
feat(data): caso banca-roles-opacidad-digital — roles y permisos como dispositivo de opacidad institucional

### DIFF
--- a/data/casos.json
+++ b/data/casos.json
@@ -389,6 +389,105 @@
         "territorio indígena",
         "derechos"
       ]
+    },
+    {
+      "id": "banca-roles-opacidad-digital",
+      "titulo": "Banca Digital — Roles, Permisos y Opacidad Institucional",
+      "anio": 2024,
+      "actores": [
+        "Aprobadores",
+        "Operadores/Digitadores",
+        "Consultores",
+        "Rol sin nombre (acceso irrestricto)",
+        "Persona Jurídica"
+      ],
+      "instituciones": [
+        "Plataforma bancaria digital",
+        "Unidad de operaciones",
+        "Módulo de roles"
+      ],
+      "etica": {
+        "titulo": "Ver sin poder actuar, actuar sin poder ver",
+        "descripcion": "El sistema de roles produce sujetos institucionales asimétricos: el Consultor que ve todo pero no puede hacer nada, no recibe notificaciones, no sabe quién tiene qué permisos. El Aprobador que veta operaciones sin saber qué decidieron sus pares. El Operador que ingresa transacciones pero no puede autorizarlas. Cada rol recibe visibilidad suficiente para su función —y no más. La opacidad sobre los roles ajenos no es falla del sistema: es su diseño.",
+        "voces": [
+          "Aprobador que aprueba sin saber si otro par ya rechazó lo mismo",
+          "Consultor que accede a toda la información material pero no puede actuar ni saber quién puede",
+          "Operador cuyo trabajo es procesado por una capa de aprobación que nunca verá"
+        ],
+        "documentos_ref": [
+          "img/Reglas_negocio_rescate(ROLES).csv"
+        ],
+        "keywords": [
+          "visibilidad segmentada",
+          "agencia",
+          "opacidad",
+          "sujeto institucional",
+          "consentimiento"
+        ],
+        "color": "#c8a96e"
+      },
+      "institucional": {
+        "titulo": "La taxonomía del permiso como régimen de verdad",
+        "descripcion": "El documento recuperado codifica una teoría institucional del acceso: Aprobador, Operador/Digitador, Consultor, y un cuarto rol sin nombre con acceso irrestricto a todo. El número de personas por rol aparece como 'S/N' (sin especificar): la institución no se compromete con cuántos tienen cada nivel de poder. 'No puede ver módulo de roles' aparece en tres de cuatro roles — la arquitectura de permisos se oculta a quienes la habitan. La nota final, 'cada persona puede tener más de un rol', introduce una multiplicidad que el registro no fija: alguien puede ser Aprobador y Operador simultáneamente, y esa combinación no tiene nombre propio en las reglas.",
+        "documentos": [
+          "Reglas de negocio plataforma bancaria digital (rescatadas de ramas)",
+          "Matriz de permisos por tipo de Persona Jurídica",
+          "Módulo de roles (visible solo para el rol sin nombre)"
+        ],
+        "clasificaciones": [
+          "Aprobador",
+          "Operador/Digitador",
+          "Consultor",
+          "Rol sin nombre (acceso irrestricto)"
+        ],
+        "keywords": [
+          "permisos",
+          "roles",
+          "acceso",
+          "taxonomía",
+          "S/N",
+          "módulo invisible"
+        ],
+        "color": "#4a7fa5"
+      },
+      "material": {
+        "titulo": "Saldos, extractos y el mapa de quién puede qué",
+        "descripcion": "Todos los roles pueden ver saldos, productos, datos y extractos de la empresa — pero solo el rol sin nombre puede ver a quién pertenece cada nivel de acceso. El 'módulo de roles' es el único artefacto que mapea el poder institucional digitalmente, y tres de cuatro roles no pueden abrirlo. El Consultor accede a toda la información material pero no puede generar ni aprobar transacciones, no recibe notificaciones, no puede ver el historial de autorizaciones. La información se desacopla completamente de la capacidad de acción.",
+        "evidencias": [
+          "CSV de reglas de negocio rescatado: 4 roles con permisos asimétricos sobre el mismo conjunto de datos",
+          "Módulo de roles visible solo para el rol sin nombre — único que puede ver el mapa completo de poder",
+          "Campo N° Personas marcado como S/N en todos los roles: la distribución real del poder no está en el registro"
+        ],
+        "keywords": [
+          "saldos",
+          "extractos",
+          "módulo de roles",
+          "notificaciones",
+          "trazabilidad"
+        ],
+        "color": "#7a9e6e"
+      },
+      "friccion": {
+        "tipo": "semantica",
+        "subtipo": "tecnica",
+        "intensidad": 0.73,
+        "estado": "abierta",
+        "descripcion": "El sistema produce fricción estructural entre visibilidad y agencia: quien puede ver más no puede hacer más, y quien puede hacer más no puede ver el mapa completo de poder. El rol sin nombre — ubicado entre Operador y Consultor en el documento, sin etiqueta asignada — es la zona de opacidad máxima: tiene todo el acceso pero no aparece nombrado en las reglas formales.",
+        "tension_central": "¿Puede existir accountability institucional cuando el mapa de quién puede qué es visible solo para quien ya tiene todo el poder?",
+        "sin_resolver": true
+      },
+      "conexiones": [
+        "sura-gobernanza-datos",
+        "periodismo-datos-chile"
+      ],
+      "tags": [
+        "banca digital",
+        "roles",
+        "permisos",
+        "opacidad institucional",
+        "accountability",
+        "artefacto rescatado"
+      ]
     }
   ]
 }

--- a/img/Reglas_negocio_rescate(ROLES).csv
+++ b/img/Reglas_negocio_rescate(ROLES).csv
@@ -1,0 +1,32 @@
+TIPO PERSONA;ROLES;N° PERSONAS;PERMISOS
+Persona Jurídica;Aprobador;S/N;Aprobar o rechazar todas las operaciones independiente de la transacción
+;;;Visualizar historial de solicitudes aprobadas o rechazadas solo de él, no de los otros aprobadores
+;;;Recibir notificaciones de aprobación o rechazo de solicitudes asignadas a él.
+;;;Puede ingresar a la transacción para revisar, pero no puede hacer modificaciones, ni ingresar transacciones.
+;;;No puede ver módulo de roles
+;;;Puede ver los saldos, los productos, los datos, los extractos, toda la información de la empresa, pero no puede ver los roles que otras personas tengan asignados
+;;;
+Persona Jurídica;Operador/ digitador;S/N;Puede ingresar transacciones
+;;;Capacidad para modificar y cancelar transacciones, antes de enviar a aprobación
+;;;Ver el detalle de las transacciones realizadas
+;;;Notificaciones de transacciones que fueron aprobadas o rechazadas que han sido ingresadas por esta persona.
+;;;No puede aprobar transacciones
+;;;Puede ver los saldos, los productos, los datos, los extractos, toda la información de la empresa, pero no puede ver los roles que otras personas tengan asignados
+;;;No puede ver módulo de roles
+;;;Visualizar historial de solicitudes aprobadas o rechazadas solo de él, no de los otros aprobadores
+;;;
+;;;Puede generar operaciones
+;;;Recibe todas las notificaciones generadas de la transacción
+;;;Puede aprobar y rechazar transacciones
+;;;No tiene limitación en ver la información del cliente, puede entrar a todos los módulos y generar todas las acciones permitidas por el sitio.
+;;;Puede ver el historial de las transacciones por aprobar
+;;;Puede ver los roles asignados a su empresa
+;;;
+Persona Jurídica;Consultor;S/N;Puede ver información del cliente, entrar a las transacciones pero no puede ingresar y aprobar transacciones
+;;;No puede operar ni autorizar.
+;;;No recibe notificaciones
+;;;No puede ser el historial de autorizaciones, ni los roles que tiene cada persona
+;;;
+;;;
+;;;
+**Cada persona puede tener más de un rol;;;


### PR DESCRIPTION
## Resumen

Integra el CSV rescatado `img/Reglas_negocio_rescate(ROLES).csv` como un caso de análisis formal en `data/casos.json`, usando el marco de tres regímenes de verdad del proyecto.

## Qué cambió

- **`data/casos.json`** — nuevo caso `banca-roles-opacidad-digital` con análisis completo en capas ética, institucional y material
- **`img/Reglas_negocio_rescate(ROLES).csv`** — fuente original versionada en el repo (estaba sin trackear)

## El caso

El CSV documenta las reglas de negocio de una plataforma bancaria digital para Persona Jurídica, con cuatro roles:

| Rol | Puede hacer | No puede ver |
|-----|-------------|--------------|
| Aprobador | Aprobar/rechazar operaciones | Historial de otros aprobadores, módulo de roles |
| Operador/Digitador | Ingresar y modificar transacciones | Aprobar, módulo de roles |
| Consultor | Ver todo | Actuar, recibir notificaciones, historial, roles |
| *(sin nombre)* | Todo sin restricciones | Nada — único con acceso al módulo de roles |

**Fricción:** `0.73` semántica/técnica. El campo N° Personas aparece como `S/N` en todos los roles: la distribución real del poder no está en el registro formal.

**Tensión central:** ¿Puede existir accountability institucional cuando el mapa de quién puede qué es visible solo para quien ya tiene todo el poder?

## Conexiones en el grafo

- → `sura-gobernanza-datos` (opacidad financiera, caja negra institucional)
- → `periodismo-datos-chile` (el dato que no dice lo que parece)

## Para el revisor

El análisis interpreta la asimetría de roles no como una falla de diseño sino como un mecanismo intencional de segmentación epistémica — coherente con el marco teórico del proyecto sobre mistranslation institucional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)