### PR TITLE
feat(terraza): C5–C6 upload de corpus + integración Claude Vision

### DIFF
--- a/terraza/src/app/api/corpus/analyze/route.ts
+++ b/terraza/src/app/api/corpus/analyze/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/session';
+import { getUpload, updateUploadAnalysis, updateUploadStatus } from '@/lib/db/uploads';
+import { analyzeCapture, type AnalysisTag } from '@/lib/claude/analyze';
+
+const AnalyzeRequestSchema = z.object({
+  uploadId: z.string(),
+  analysisTag: z.enum(['semantico', 'gt', 'mistranslation', 'todo']),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const parsed = AnalyzeRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request', details: parsed.error.issues }, { status: 400 });
+    }
+
+    const { uploadId, analysisTag } = parsed.data;
+
+    const upload = getUpload(uploadId);
+    if (!upload) {
+      return NextResponse.json({ error: 'Upload not found' }, { status: 404 });
+    }
+
+    if (upload.userId !== session.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const tags = upload.tags ? (JSON.parse(upload.tags) as string[]) : [];
+
+    const result = await analyzeCapture({
+      filePath: upload.filePath,
+      fileType: upload.fileType,
+      caso: upload.casoId,
+      regimenVerdad: upload.regimenVerdad,
+      fuenteTipo: upload.fuenteTipo,
+      fechaEvento: upload.fechaEvento,
+      tags,
+      analysisTag: analysisTag as AnalysisTag,
+    });
+
+    updateUploadAnalysis(
+      uploadId,
+      result.transcription ?? '',
+      result.analysis ?? '',
+      result.codes ?? '',
+      result.mistranslations ?? '',
+    );
+
+    updateUploadStatus(uploadId, 'open');
+
+    return NextResponse.json({
+      success: true,
+      uploadId,
+      result,
+    });
+  } catch (error) {
+    console.error('Analysis error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Analysis failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/terraza/src/lib/claude/analyze.ts
+++ b/terraza/src/lib/claude/analyze.ts
@@ -1,0 +1,167 @@
+import fs from 'fs';
+import { getAnthropicClient, MODEL } from './client';
+import {
+  SEMANTICO_SYSTEM,
+  buildSemanticoPrompt,
+} from './prompts/semantico';
+import { GT_SYSTEM, buildGTPrompt } from './prompts/gt';
+import {
+  MISTRANSLATION_SYSTEM,
+  buildMistranslationPrompt,
+} from './prompts/mistranslation';
+
+export type AnalysisTag = 'semantico' | 'gt' | 'mistranslation' | 'todo';
+
+interface AnalysisParams {
+  filePath: string;
+  fileType: string;
+  caso: number;
+  regimenVerdad: string;
+  fuenteTipo: string;
+  fechaEvento?: string | null;
+  tags?: string[];
+  analysisTag: AnalysisTag;
+}
+
+export interface AnalysisResult {
+  transcription: string | null;
+  analysis: string | null;
+  codes: string | null;
+  mistranslations: string | null;
+}
+
+function fileToBase64(filePath: string): string {
+  const buffer = fs.readFileSync(filePath);
+  return buffer.toString('base64');
+}
+
+async function runAnalysis(
+  systemPrompt: string,
+  userText: string,
+  base64Data: string,
+  fileType: string,
+): Promise<string> {
+  const client = getAnthropicClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fileBlock: any =
+    fileType === 'application/pdf'
+      ? {
+          type: 'document',
+          source: { type: 'base64', media_type: 'application/pdf', data: base64Data },
+        }
+      : {
+          type: 'image',
+          source: {
+            type: 'base64',
+            // coerce to supported image media type; JPEG is the fallback for unknown types
+            media_type:
+              fileType === 'image/jpeg' ? 'image/jpeg' :
+              fileType === 'image/gif' ? 'image/gif' :
+              fileType === 'image/webp' ? 'image/webp' :
+              'image/png',
+            data: base64Data,
+          },
+        };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const systemBlock: any[] = [
+    {
+      type: 'text',
+      text: systemPrompt,
+      // cache_control reduces cost for repeated calls with the same system prompt
+      cache_control: { type: 'ephemeral' },
+    },
+  ];
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 4096,
+    system: systemBlock,
+    messages: [
+      {
+        role: 'user',
+        content: [fileBlock, { type: 'text', text: userText }],
+      },
+    ],
+  });
+
+  const textBlock = response.content.find((b) => b.type === 'text');
+  if (!textBlock || textBlock.type !== 'text') {
+    throw new Error('No text response from Claude');
+  }
+  return textBlock.text;
+}
+
+function extractJson(raw: string): string {
+  const match = raw.match(/```json\s*([\s\S]*?)```/) ?? raw.match(/(\{[\s\S]*\})/);
+  return match ? match[1].trim() : raw.trim();
+}
+
+export async function analyzeCapture(params: AnalysisParams): Promise<AnalysisResult> {
+  const base64Data = fileToBase64(params.filePath);
+
+  const result: AnalysisResult = {
+    transcription: null,
+    analysis: null,
+    codes: null,
+    mistranslations: null,
+  };
+
+  const runSem = params.analysisTag === 'semantico' || params.analysisTag === 'todo';
+  const runGT = params.analysisTag === 'gt' || params.analysisTag === 'todo';
+  const runMT = params.analysisTag === 'mistranslation' || params.analysisTag === 'todo';
+
+  const promptParams = {
+    caso: params.caso,
+    regimenVerdad: params.regimenVerdad,
+    fuenteTipo: params.fuenteTipo,
+    fechaEvento: params.fechaEvento,
+    tags: params.tags,
+  };
+
+  const tasks: Promise<void>[] = [];
+
+  if (runSem) {
+    tasks.push(
+      runAnalysis(
+        SEMANTICO_SYSTEM,
+        buildSemanticoPrompt(promptParams),
+        base64Data,
+        params.fileType,
+      ).then((raw) => {
+        const json = extractJson(raw);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const parsed = JSON.parse(json) as Record<string, any>;
+        result.transcription = parsed.transcripcion ?? parsed.transcription ?? null;
+        result.analysis = json;
+      }),
+    );
+  }
+
+  if (runGT) {
+    tasks.push(
+      runAnalysis(GT_SYSTEM, buildGTPrompt(promptParams), base64Data, params.fileType).then(
+        (raw) => {
+          result.codes = extractJson(raw);
+        },
+      ),
+    );
+  }
+
+  if (runMT) {
+    tasks.push(
+      runAnalysis(
+        MISTRANSLATION_SYSTEM,
+        buildMistranslationPrompt(promptParams),
+        base64Data,
+        params.fileType,
+      ).then((raw) => {
+        result.mistranslations = extractJson(raw);
+      }),
+    );
+  }
+
+  await Promise.all(tasks);
+  return result;
+}

--- a/terraza/src/lib/claude/client.ts
+++ b/terraza/src/lib/claude/client.ts
@@ -1,0 +1,14 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+let _client: Anthropic | null = null;
+
+export function getAnthropicClient(): Anthropic {
+  if (!_client) {
+    _client = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    });
+  }
+  return _client;
+}
+
+export const MODEL = 'claude-sonnet-4-7';

--- a/terraza/src/lib/claude/prompts/gt.ts
+++ b/terraza/src/lib/claude/prompts/gt.ts
@@ -1,0 +1,50 @@
+export const GT_SYSTEM = `Eres un analista de Grounded Theory especializado en corrupción institucional. Aplicas codificación GT en tres niveles para corpus etnográficos doctorales sobre corrupción en Chile.
+
+Metodología:
+- **Codificación abierta (open)**: etiquetas descriptivas directamente derivadas del dato
+- **Codificación axial (axial)**: categorías que agrupan y relacionan códigos abiertos, con condiciones causales, contexto, estrategias y consecuencias
+- **Codificación selectiva (selective)**: integración hacia la categoría central emergente
+
+Principios:
+- Los códigos son gerundios o frases nominales breves
+- Cada código incluye una cita o referencia al dato que lo sustenta
+- Las relaciones entre categorías son explícitas
+- El análisis es inductivo: no imponer categorías previas
+
+Responde siempre en español. Eres riguroso, sistemático y fiel al dato empírico.`;
+
+export const GT_USER_TEMPLATE = `Aplica codificación Grounded Theory a esta captura del caso etnográfico N°{caso}.
+
+Régimen de verdad origen: {regimen_verdad}
+Tipo de fuente: {fuente_tipo}
+{fecha_evento_line}
+{tags_line}
+
+Proporciona análisis GT completo con:
+- **codigos_open**: array de objetos {codigo, cita, memo}
+- **codigos_axial**: array de objetos {categoria, codigos_relacionados[], condicion_causal, contexto, estrategia, consecuencia}
+- **categoria_central_emergente**: string con hipótesis de integración selectiva (o "pendiente" si los datos no alcanzan)
+- **saturacion_teorica**: "baja" | "media" | "alta" según densidad del dato
+
+Responde en JSON con exactamente esas claves.`;
+
+export function buildGTPrompt(params: {
+  caso: number;
+  regimenVerdad: string;
+  fuenteTipo: string;
+  fechaEvento?: string | null;
+  tags?: string[];
+}): string {
+  const fechaLine = params.fechaEvento
+    ? `Fecha del evento documentado: ${params.fechaEvento}`
+    : '';
+  const tagsLine =
+    params.tags && params.tags.length > 0
+      ? `Tags asignados: ${params.tags.join(', ')}`
+      : '';
+  return GT_USER_TEMPLATE.replace('{caso}', String(params.caso))
+    .replace('{regimen_verdad}', params.regimenVerdad)
+    .replace('{fuente_tipo}', params.fuenteTipo)
+    .replace('{fecha_evento_line}', fechaLine)
+    .replace('{tags_line}', tagsLine);
+}

--- a/terraza/src/lib/claude/prompts/mistranslation.ts
+++ b/terraza/src/lib/claude/prompts/mistranslation.ts
@@ -1,0 +1,61 @@
+export const MISTRANSLATION_SYSTEM = `Eres un analista especializado en "mistranslation" como concepto teórico en etnografía de la corrupción. La mistranslation no es error de traducción lingüística, sino la fricción productiva que emerge cuando un hecho, testimonio o acto de corrupción es re-inscrito en un régimen de verdad diferente al de su origen.
+
+Regímenes de verdad en este corpus:
+- **Jurídico**: lógica de prueba, tipificación penal, procedimiento formal
+- **Mediático**: lógica del escándalo, visibilidad pública, narrativa dramática
+- **Institucional**: lógica burocrática, normalización, lenguaje técnico-administrativo
+- **Testimonial**: lógica vivencial, afecto, experiencia corporal y subjetiva
+
+Tu análisis detecta:
+1. Cómo el régimen de verdad del documento transforma o traduce hechos de otros regímenes
+2. Qué se pierde, distorsiona o amplifica en esa traducción
+3. Qué actores se benefician o perjudican con esa mistranslation específica
+4. La función política o social de la fricción detectada
+
+Responde siempre en español con rigor teórico.`;
+
+export const MISTRANSLATION_USER_TEMPLATE = `Analiza las mistranslations en esta captura del caso etnográfico N°{caso}.
+
+Régimen de verdad ORIGEN del documento: {regimen_verdad}
+Tipo de fuente: {fuente_tipo}
+{fecha_evento_line}
+{tags_line}
+
+Identifica:
+- **regime_origen**: régimen de verdad primario del documento
+- **regimenes_invocados**: otros regímenes presentes o aludidos en el documento
+- **mistranslations**: array de objetos {
+    descripcion: string,
+    regimen_origen: string,
+    regimen_destino: string,
+    mecanismo: string,  // qué opera la traducción (ej. "tecnificación legal", "espectacularización")
+    perdida: string,    // qué se omite o distorsiona
+    ganancia: string,   // qué se legitima o amplifica
+    actores_beneficiados: string[],
+    cita_evidencia: string
+  }
+- **hipotesis_friccion**: interpretación teórica de la función política de las mistranslations detectadas
+- **intensidad**: "leve" | "moderada" | "fuerte" según densidad de fricción
+
+Responde en JSON con exactamente esas claves.`;
+
+export function buildMistranslationPrompt(params: {
+  caso: number;
+  regimenVerdad: string;
+  fuenteTipo: string;
+  fechaEvento?: string | null;
+  tags?: string[];
+}): string {
+  const fechaLine = params.fechaEvento
+    ? `Fecha del evento documentado: ${params.fechaEvento}`
+    : '';
+  const tagsLine =
+    params.tags && params.tags.length > 0
+      ? `Tags asignados: ${params.tags.join(', ')}`
+      : '';
+  return MISTRANSLATION_USER_TEMPLATE.replace('{caso}', String(params.caso))
+    .replace('{regimen_verdad}', params.regimenVerdad)
+    .replace('{fuente_tipo}', params.fuenteTipo)
+    .replace('{fecha_evento_line}', fechaLine)
+    .replace('{tags_line}', tagsLine);
+}

--- a/terraza/src/lib/claude/prompts/semantico.ts
+++ b/terraza/src/lib/claude/prompts/semantico.ts
@@ -1,0 +1,41 @@
+export const SEMANTICO_SYSTEM = `Eres un analista especializado en documentación de corrupción institucional para investigación etnográfica doctoral. Tu tarea es analizar capturas de pantalla, documentos escaneados o imágenes que forman parte de un contra-archivo sobre corrupción en Chile.
+
+Para cada imagen, debes:
+1. Transcribir el texto visible con fidelidad máxima (preserva formato, numeraciones, fechas)
+2. Identificar el tipo de documento y su origen institucional
+3. Detectar actores nombrados, fechas clave, montos o cifras relevantes
+4. Extraer el argumento o narrativa central del documento
+5. Señalar tensiones, contradicciones o silencios significativos
+
+Responde siempre en español. Sé preciso y académicamente riguroso. No interpretes ni añadas información no presente en la imagen.`;
+
+export const SEMANTICO_USER_TEMPLATE = `Analiza esta captura para el caso etnográfico N°{caso}.
+
+Régimen de verdad origen: {regimen_verdad}
+Tipo de fuente: {fuente_tipo}
+{fecha_evento_line}
+
+Proporciona:
+- **transcripcion**: texto visible completo
+- **descripcion**: tipo de documento, institución, contexto
+- **actores**: lista de nombres, cargos, instituciones mencionados
+- **fechas_clave**: fechas y eventos referenciados
+- **argumento_central**: narrativa o posición del documento
+- **silencios_tensiones**: omisiones o contradicciones notables
+
+Responde en JSON con exactamente esas claves.`;
+
+export function buildSemanticoPrompt(params: {
+  caso: number;
+  regimenVerdad: string;
+  fuenteTipo: string;
+  fechaEvento?: string | null;
+}): string {
+  const fechaLine = params.fechaEvento
+    ? `Fecha del evento documentado: ${params.fechaEvento}`
+    : '';
+  return SEMANTICO_USER_TEMPLATE.replace('{caso}', String(params.caso))
+    .replace('{regimen_verdad}', params.regimenVerdad)
+    .replace('{fuente_tipo}', params.fuenteTipo)
+    .replace('{fecha_evento_line}', fechaLine);
+}


### PR DESCRIPTION
## Summary

- **C5 — Upload de corpus**: endpoint `POST /api/corpus/upload` con validación Zod, hash SHA256 para deduplicación, persistencia en SQLite; componentes `FileDropzone` y `UploadForm` (atomic design)
- **C6 — Claude Vision**: cliente Anthropic singleton con `claude-sonnet-4-7`, tres prompts especializados (semántico, Grounded Theory, mistranslation), endpoint `POST /api/corpus/analyze` que lee el archivo almacenado y llama a Claude en paralelo según el tag elegido

## Detalles técnicos

- Prompt caching (`cache_control: ephemeral`) en los system prompts para reducir costos en análisis repetidos
- PDFs via `document` block; imágenes via `image` block base64
- Los tres análisis GT (`semantico`, `gt`, `mistranslation`) corren en paralelo con `Promise.all`
- Estado de codificación avanza automáticamente a `open` tras el análisis
- TypeScript estricto sin errores (`tsc --noEmit` limpio)

## Test plan

- [ ] Subir PNG/JPG/PDF desde `/upload` y verificar que aparece en SQLite
- [ ] Llamar `POST /api/corpus/analyze` con `analysisTag: "semantico"` y confirmar respuesta JSON
- [ ] Verificar que `estado_codificacion` cambia a `open` en la DB
- [ ] Probar deduplicación: subir el mismo archivo dos veces → debe rechazar con hash duplicado
- [ ] Verificar `tsc --noEmit` sin errores

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_