### PR TITLE
feat(terraza): C8–C9 — audit HTML/a11y + sync simple-git + cola de commits

### DIFF
--- a/terraza/src/app/api/corpus/commit/route.ts
+++ b/terraza/src/app/api/corpus/commit/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/session';
+import { getUpload } from '@/lib/db/uploads';
+import { createCommitQueueEntry, updateCommitStatus } from '@/lib/db/commit-queue';
+import { commitCaptureToRepo } from '@/lib/git/corpus-writer';
+
+const CommitRequestSchema = z.object({
+  uploadId: z.string(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const parsed = CommitRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    }
+
+    const { uploadId } = parsed.data;
+    const upload = getUpload(uploadId);
+
+    if (!upload) {
+      return NextResponse.json({ error: 'Upload not found' }, { status: 404 });
+    }
+    if (upload.userId !== session.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (upload.estadoCodificacion === 'pendiente') {
+      return NextResponse.json(
+        { error: 'La captura aún no tiene análisis. Ejecuta el análisis primero.' },
+        { status: 422 },
+      );
+    }
+
+    const queueEntry = createCommitQueueEntry(uploadId);
+
+    try {
+      const commitHash = await commitCaptureToRepo(upload);
+      updateCommitStatus(queueEntry.id, 'committed', commitHash);
+      return NextResponse.json({ success: true, commitHash, queueId: queueEntry.id });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Git commit failed';
+      updateCommitStatus(queueEntry.id, 'error', undefined, msg);
+      return NextResponse.json({ error: msg }, { status: 500 });
+    }
+  } catch (error) {
+    console.error('Commit error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/terraza/src/app/api/corpus/sync-status/route.ts
+++ b/terraza/src/app/api/corpus/sync-status/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { getPendingCommits, updateCommitStatus } from '@/lib/db/commit-queue';
+import { getRemoteSyncStatus } from '@/lib/git/corpus-writer';
+import { updateUploadStatus } from '@/lib/db/uploads';
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const pending = getPendingCommits();
+    let remoteStatus = { ahead: 0, behind: 0 };
+
+    try {
+      remoteStatus = await getRemoteSyncStatus();
+    } catch {
+      // Corpus repo not configured or offline — return pending list only
+    }
+
+    // If remote is no longer ahead of our committed entries, mark them synced
+    if (remoteStatus.ahead === 0 && pending.length > 0) {
+      for (const entry of pending) {
+        if (entry.status === 'committed') {
+          updateCommitStatus(entry.id, 'synced');
+          updateUploadStatus(entry.uploadId, 'verificado');
+        }
+      }
+    }
+
+    const updatedPending = getPendingCommits();
+
+    return NextResponse.json({
+      pending: updatedPending,
+      remoteStatus,
+    });
+  } catch (error) {
+    console.error('Sync status error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/terraza/src/components/organisms/CaptureCard.tsx
+++ b/terraza/src/components/organisms/CaptureCard.tsx
@@ -21,6 +21,7 @@ interface CaptureCardProps {
     createdAt: number;
   };
   onAnalyzed?: (uploadId: string) => void;
+  onCommitted?: (uploadId: string) => void;
   onSelect?: (uploadId: string) => void;
   isSelected?: boolean;
 }
@@ -53,8 +54,9 @@ function casoLabel(casoId: 1 | 2 | 3 | 4): string {
   return caso?.label ?? `Caso ${casoId}`;
 }
 
-export function CaptureCard({ upload, onAnalyzed, onSelect, isSelected = false }: CaptureCardProps) {
+export function CaptureCard({ upload, onAnalyzed, onCommitted, onSelect, isSelected = false }: CaptureCardProps) {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [isCommitting, setIsCommitting] = useState(false);
   const [analysisTag, setAnalysisTag] = useState<string>('semantico');
   const [error, setError] = useState<string | null>(null);
 
@@ -76,6 +78,28 @@ export function CaptureCard({ upload, onAnalyzed, onSelect, isSelected = false }
       setError(err instanceof Error ? err.message : 'Analysis failed');
     } finally {
       setIsAnalyzing(false);
+    }
+  };
+
+  const handleCommit = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsCommitting(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/corpus/commit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uploadId: upload.id }),
+      });
+      if (!response.ok) {
+        const data = await response.json() as { error?: string };
+        throw new Error(data.error ?? 'Commit failed');
+      }
+      if (onCommitted) onCommitted(upload.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Commit failed');
+    } finally {
+      setIsCommitting(false);
     }
   };
 
@@ -160,8 +184,31 @@ export function CaptureCard({ upload, onAnalyzed, onSelect, isSelected = false }
         </div>
       )}
 
+      {/* Commit button for analyzed captures */}
+      {estado !== 'pendiente' && (
+        <div className="mt-2" onClick={(e) => e.stopPropagation()}>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isCommitting}
+            onClick={handleCommit}
+            className="w-full text-xs py-1.5"
+            aria-label={`Commitear captura ${upload.fileName} al repo privado`}
+          >
+            {isCommitting ? (
+              <span className="flex items-center justify-center gap-1.5">
+                <Spinner size="sm" />
+                Commiteando…
+              </span>
+            ) : (
+              'Commitear al repo'
+            )}
+          </Button>
+        </div>
+      )}
+
       {error && (
-        <p className="mt-2 text-xs text-red-700 bg-red-50 px-2 py-1 rounded">{error}</p>
+        <p role="alert" className="mt-2 text-xs text-red-700 bg-red-50 px-2 py-1 rounded">{error}</p>
       )}
 
       <p className="text-xs text-gray-400 mt-2">

--- a/terraza/src/components/organisms/CommitQueue.tsx
+++ b/terraza/src/components/organisms/CommitQueue.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/atoms/Button';
+import { Spinner } from '@/components/atoms/Spinner';
+
+interface CommitEntry {
+  id: string;
+  uploadId: string;
+  commitHash: string | null;
+  status: 'pending' | 'committed' | 'synced' | 'error';
+  errorMessage: string | null;
+  createdAt: number;
+}
+
+interface RemoteStatus {
+  ahead: number;
+  behind: number;
+}
+
+interface SyncStatusResponse {
+  pending: CommitEntry[];
+  remoteStatus: RemoteStatus;
+}
+
+const STATUS_LABELS: Record<CommitEntry['status'], string> = {
+  pending: 'Pendiente',
+  committed: 'Commiteado — esperando push',
+  synced: 'Sincronizado',
+  error: 'Error',
+};
+
+const STATUS_COLORS: Record<CommitEntry['status'], string> = {
+  pending: 'bg-gray-100 text-gray-700',
+  committed: 'bg-amber-100 text-amber-800',
+  synced: 'bg-green-100 text-green-700',
+  error: 'bg-red-100 text-red-700',
+};
+
+export function CommitQueue() {
+  const [entries, setEntries] = useState<CommitEntry[]>([]);
+  const [remoteStatus, setRemoteStatus] = useState<RemoteStatus>({ ahead: 0, behind: 0 });
+  const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch('/api/corpus/sync-status');
+      if (!res.ok) {
+        const d = await res.json() as { error?: string };
+        setFetchError(d.error ?? 'Error al verificar sync');
+        return;
+      }
+      const data = await res.json() as SyncStatusResponse;
+      setEntries(data.pending);
+      setRemoteStatus(data.remoteStatus);
+      setFetchError(null);
+    } catch {
+      setFetchError('Error de red al verificar sincronización');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchStatus();
+    // Poll every 30s to detect GitHub Desktop push
+    const interval = setInterval(() => void fetchStatus(), 30_000);
+    return () => clearInterval(interval);
+  }, [fetchStatus]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-sm text-gray-500" aria-busy="true">
+        <Spinner size="sm" />
+        <span>Comprobando sincronización…</span>
+      </div>
+    );
+  }
+
+  if (entries.length === 0 && !fetchError) {
+    return (
+      <p className="text-sm text-gray-500 py-4 text-center">
+        No hay commits pendientes.
+      </p>
+    );
+  }
+
+  const committedCount = entries.filter((e) => e.status === 'committed').length;
+
+  return (
+    <div className="space-y-4">
+      {committedCount > 0 && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-start gap-3 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm"
+        >
+          <span className="text-amber-600 mt-0.5" aria-hidden="true">⚠</span>
+          <div>
+            <p className="font-medium text-amber-800">
+              {committedCount} commit{committedCount > 1 ? 's' : ''} pendiente{committedCount > 1 ? 's' : ''} de push
+            </p>
+            <p className="text-amber-700 mt-0.5">
+              Abre GitHub Desktop para hacer push al repo privado.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {remoteStatus.behind > 0 && (
+        <p className="text-xs text-blue-700 bg-blue-50 px-3 py-2 rounded border border-blue-200">
+          El repo local está {remoteStatus.behind} commit{remoteStatus.behind > 1 ? 's' : ''} detrás del remoto.
+        </p>
+      )}
+
+      {entries.length > 0 && (
+        <ul className="space-y-2" aria-label="Cola de commits">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              className="flex items-center justify-between gap-3 p-3 border border-gray-200 rounded-lg bg-white"
+            >
+              <div className="min-w-0">
+                <p className="text-xs font-mono text-gray-600 truncate">
+                  {entry.commitHash ? entry.commitHash.slice(0, 8) : '—'}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {new Date(entry.createdAt).toLocaleDateString('es-CL', {
+                    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
+                  })}
+                </p>
+                {entry.errorMessage && (
+                  <p className="text-xs text-red-700 mt-1">{entry.errorMessage}</p>
+                )}
+              </div>
+              <span
+                className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[entry.status]}`}
+              >
+                {STATUS_LABELS[entry.status]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Button
+        type="button"
+        variant="secondary"
+        onClick={() => void fetchStatus()}
+        className="w-full text-sm"
+        aria-label="Verificar estado de sincronización con el repositorio remoto"
+      >
+        Verificar sync
+      </Button>
+
+      {fetchError && (
+        <p role="alert" className="text-xs text-red-700 bg-red-50 px-3 py-2 rounded border border-red-200">
+          {fetchError}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/terraza/src/lib/db/commit-queue.ts
+++ b/terraza/src/lib/db/commit-queue.ts
@@ -1,0 +1,73 @@
+import { getDatabase } from './init';
+import { v4 as uuidv4 } from 'uuid';
+
+export type CommitStatus = 'pending' | 'committed' | 'synced' | 'error';
+
+export interface CommitQueueRecord {
+  id: string;
+  uploadId: string;
+  commitHash: string | null;
+  status: CommitStatus;
+  errorMessage: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function rowToRecord(row: Record<string, unknown>): CommitQueueRecord {
+  return {
+    id: row.id as string,
+    uploadId: row.upload_id as string,
+    commitHash: (row.commit_hash as string) || null,
+    status: row.status as CommitStatus,
+    errorMessage: (row.error_message as string) || null,
+    createdAt: row.created_at as number,
+    updatedAt: row.updated_at as number,
+  };
+}
+
+export function createCommitQueueEntry(uploadId: string): CommitQueueRecord {
+  const db = getDatabase();
+  const id = uuidv4();
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO commit_queue (id, upload_id, status, created_at, updated_at)
+    VALUES (?, ?, 'pending', ?, ?)
+  `).run(id, uploadId, now, now);
+  return { id, uploadId, commitHash: null, status: 'pending', errorMessage: null, createdAt: now, updatedAt: now };
+}
+
+export function updateCommitStatus(
+  id: string,
+  status: CommitStatus,
+  commitHash?: string,
+  errorMessage?: string,
+): void {
+  const db = getDatabase();
+  db.prepare(`
+    UPDATE commit_queue
+    SET status = ?, commit_hash = ?, error_message = ?, updated_at = ?
+    WHERE id = ?
+  `).run(status, commitHash ?? null, errorMessage ?? null, Date.now(), id);
+}
+
+export function getPendingCommits(): CommitQueueRecord[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    `SELECT * FROM commit_queue WHERE status IN ('pending', 'committed') ORDER BY created_at ASC`,
+  ).all() as Record<string, unknown>[];
+  return rows.map(rowToRecord);
+}
+
+export function getCommitQueueByUpload(uploadId: string): CommitQueueRecord | null {
+  const db = getDatabase();
+  const row = db.prepare('SELECT * FROM commit_queue WHERE upload_id = ? ORDER BY created_at DESC LIMIT 1').get(uploadId) as Record<string, unknown> | undefined;
+  return row ? rowToRecord(row) : null;
+}
+
+export function getAllCommitQueue(limit = 50): CommitQueueRecord[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    'SELECT * FROM commit_queue ORDER BY created_at DESC LIMIT ?',
+  ).all(limit) as Record<string, unknown>[];
+  return rows.map(rowToRecord);
+}

--- a/terraza/src/lib/db/schema.sql
+++ b/terraza/src/lib/db/schema.sql
@@ -45,6 +45,19 @@ CREATE TABLE IF NOT EXISTS uploads (
   FOREIGN KEY (user_id) REFERENCES credentials(user_id)
 );
 
+-- Commit queue: tracks local git commits pending push
+CREATE TABLE IF NOT EXISTS commit_queue (
+  id TEXT PRIMARY KEY,
+  upload_id TEXT NOT NULL,
+  commit_hash TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK(status IN ('pending', 'committed', 'synced', 'error')),
+  error_message TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (upload_id) REFERENCES uploads(id)
+);
+
 -- Create indexes for faster lookups
 CREATE INDEX IF NOT EXISTS idx_credentials_user_id ON credentials(user_id);
 CREATE INDEX IF NOT EXISTS idx_credentials_user_name ON credentials(user_name);

--- a/terraza/src/lib/git/corpus-writer.ts
+++ b/terraza/src/lib/git/corpus-writer.ts
@@ -1,0 +1,170 @@
+import fs from 'fs';
+import path from 'path';
+import simpleGit, { type SimpleGit } from 'simple-git';
+import { CASOS } from '@/lib/corpus/cases';
+import type { UploadRecord } from '@/lib/db/uploads';
+
+const CORPUS_REPO_PATH = process.env.CORPUS_REPO_PATH ?? '';
+
+function getGit(): SimpleGit {
+  if (!CORPUS_REPO_PATH) {
+    throw new Error('CORPUS_REPO_PATH env var not set');
+  }
+  if (!fs.existsSync(CORPUS_REPO_PATH)) {
+    throw new Error(`Corpus repo not found at: ${CORPUS_REPO_PATH}`);
+  }
+  return simpleGit(CORPUS_REPO_PATH);
+}
+
+function casoSlug(casoId: 1 | 2 | 3 | 4): string {
+  const caso = Object.values(CASOS).find((c) => c.id === casoId);
+  return caso?.slug ?? `caso-${casoId}`;
+}
+
+function buildSlug(upload: UploadRecord): string {
+  const ext = path.extname(upload.fileName);
+  const base = path.basename(upload.fileName, ext)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .slice(0, 40);
+  return base || upload.id.slice(0, 8);
+}
+
+function captureDir(upload: UploadRecord): string {
+  const fecha = upload.fechaEvento
+    ? upload.fechaEvento.slice(0, 10)
+    : new Date(upload.createdAt).toISOString().slice(0, 10);
+  const slug = buildSlug(upload);
+  const caso = casoSlug(upload.casoId);
+  return path.join(CORPUS_REPO_PATH, 'corpus', caso, `${fecha}-${slug}`);
+}
+
+export interface WriteResult {
+  dir: string;
+  files: string[];
+}
+
+export function writeCaptureToDisk(upload: UploadRecord): WriteResult {
+  const dir = captureDir(upload);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const files: string[] = [];
+
+  // source file
+  const srcExt = path.extname(upload.fileName);
+  const sourceDest = path.join(dir, `source${srcExt}`);
+  fs.copyFileSync(upload.filePath, sourceDest);
+  files.push(sourceDest);
+
+  // metadata.json
+  const tags = upload.tags ? (JSON.parse(upload.tags) as string[]) : [];
+  const metadata = {
+    id: upload.id,
+    caso: upload.casoId,
+    fecha_captura: new Date(upload.createdAt).toISOString(),
+    fecha_evento: upload.fechaEvento ?? null,
+    fuente_tipo: upload.fuenteTipo,
+    regimen_verdad_origen: upload.regimenVerdad,
+    tags,
+    estado_codificacion: upload.estadoCodificacion,
+    hash_source: upload.hashSource,
+  };
+  const metaPath = path.join(dir, 'metadata.json');
+  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), 'utf-8');
+  files.push(metaPath);
+
+  // transcription.md
+  if (upload.transcription) {
+    const transcPath = path.join(dir, 'transcription.md');
+    fs.writeFileSync(transcPath, upload.transcription, 'utf-8');
+    files.push(transcPath);
+  }
+
+  // analysis.md
+  if (upload.analysis) {
+    const analysisPath = path.join(dir, 'analysis.md');
+    fs.writeFileSync(analysisPath, upload.analysis, 'utf-8');
+    files.push(analysisPath);
+  }
+
+  // codes.json
+  if (upload.codes) {
+    const codesPath = path.join(dir, 'codes.json');
+    fs.writeFileSync(codesPath, upload.codes, 'utf-8');
+    files.push(codesPath);
+  }
+
+  // mistranslations.json
+  if (upload.mistranslations) {
+    const mtPath = path.join(dir, 'mistranslations.json');
+    fs.writeFileSync(mtPath, upload.mistranslations, 'utf-8');
+    files.push(mtPath);
+  }
+
+  return { dir, files };
+}
+
+function buildCommitMessage(upload: UploadRecord): string {
+  const tags = upload.tags ? (JSON.parse(upload.tags) as string[]) : [];
+  const fecha = upload.fechaEvento
+    ? upload.fechaEvento.slice(0, 10)
+    : new Date(upload.createdAt).toISOString().slice(0, 10);
+  const slug = buildSlug(upload);
+
+  const analysisTag = tags.length > 0 ? tags.join(', ') : 'sin-tag';
+
+  // Count codes if available
+  let codesLine = '';
+  if (upload.codes) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const codes = JSON.parse(upload.codes) as Record<string, any>;
+      const open = Array.isArray(codes.codigos_open) ? codes.codigos_open.length : '?';
+      const axial = Array.isArray(codes.codigos_axial) ? codes.codigos_axial.length : '?';
+      codesLine = `\n- Códigos open: ${open} | axial: ${axial} | selective: pendiente`;
+    } catch {
+      // malformed JSON — skip
+    }
+  }
+
+  return [
+    `corpus(caso-${upload.casoId}): añade captura ${fecha}-${slug}`,
+    '',
+    `- Régimen origen: ${upload.regimenVerdad}`,
+    `- Tag análisis: ${analysisTag}`,
+    codesLine,
+  ]
+    .join('\n')
+    .trim();
+}
+
+export async function commitCaptureToRepo(upload: UploadRecord): Promise<string> {
+  const git = getGit();
+  const { files } = writeCaptureToDisk(upload);
+
+  const gitUserName = process.env.GIT_USER_NAME ?? 'Contra-archivo';
+  const gitUserEmail = process.env.GIT_USER_EMAIL ?? 'terraza@local';
+
+  await git.addConfig('user.name', gitUserName, false, 'local');
+  await git.addConfig('user.email', gitUserEmail, false, 'local');
+
+  // Stage only the new capture files
+  const relFiles = files.map((f) => path.relative(CORPUS_REPO_PATH, f));
+  await git.add(relFiles);
+
+  const message = buildCommitMessage(upload);
+  const result = await git.commit(message);
+
+  return result.commit;
+}
+
+export async function getRemoteSyncStatus(): Promise<{ ahead: number; behind: number }> {
+  const git = getGit();
+  try {
+    await git.fetch('origin', 'main');
+    const status = await git.status();
+    return { ahead: status.ahead, behind: status.behind };
+  } catch {
+    return { ahead: 0, behind: 0 };
+  }
+}


### PR DESCRIPTION
## Summary

**C8 — Audit HTML/accesibilidad + fixes Codex:**
- Skip-to-main link en root layout (`#main-content`)
- Admin layout: `<nav aria-label>` + `aria-current="page"` via `usePathname`
- Login page: passkey authentication wired (antes era botón estático sin handler)
- FileDropzone: `role="button"` + `tabIndex` + `onKeyDown` (Enter/Space) — WCAG 2.1 SC 2.1.1
- AnalysisPanel: roving tabindex en tabs + ArrowLeft/Right/Home/End
- Todos los errores usan `role="alert"`, confirmaciones usan `aria-live="polite"`
- DB: índice en `estado_codificacion`, auto-cleanup de challenges en cold start
- Fix P1 Codex: `key={upload.id}` → resetea estado del editor al cambiar captura
- Fix P2 Codex: sanitización de `limit` en `/api/corpus/list`
- CLAUDE.md: estado del proyecto + buenas prácticas obligatorias para IAs colaboradoras

**C9 — Sync con repo privado (F3):**
- `lib/git/corpus-writer.ts`: escribe estructura corpus al repo privado clonado, buildea mensaje de commit semántico, git add + commit local
- `lib/db/commit-queue.ts` + tabla SQL: cola pending → committed → synced → error
- `POST /api/corpus/commit`: copia archivos + git commit (nunca push)
- `GET /api/corpus/sync-status`: polling — detecta push de GitHub Desktop, marca synced automáticamente
- `CommitQueue` organism: lista con polling 30s, aviso "abre GitHub Desktop"
- `CaptureCard`: botón "Commitear al repo" para capturas con análisis

## Test plan

- [ ] Navegación admin con teclado — verificar skip link, aria-current, tabs con arrow keys
- [ ] FileDropzone: tab hasta la zona, Enter abre selector de archivos
- [ ] Login: botón Entrar con passkey ejecuta el flow WebAuthn completo
- [ ] Subir captura → analizar → botón "Commitear al repo" (requiere `CORPUS_REPO_PATH` configurado)
- [ ] `/api/corpus/sync-status` devuelve lista de commits pendientes
- [ ] Hacer push en GitHub Desktop → verificar sync automático en próxima poll

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_