### PR TITLE
feat(terraza): C10 — cola de commits integrada en corpus + CLAUDE.md actualizado

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,31 +20,24 @@ App admin **privada** para alimentar el contra-archivo doctoral de Rö (antropol
 | C4 | SQLite: schema + credentials + challenges + sessions | ✅ |
 | C5 | Upload: FileDropzone + UploadForm + API `/corpus/upload` | ✅ |
 | C6 | Claude Vision: 3 prompts (semántico, GT, mistranslation) + API `/corpus/analyze` | ✅ |
-| C7 | Corpus browser: CaptureCard + AnalysisPanel + APIs list/update | ✅ en branch, PR #82 |
+| C7 | Corpus browser: CaptureCard + AnalysisPanel + APIs list/update | ✅ |
+| C8 | Audit HTML/a11y: skip link, nav semántico, login wired, WCAG 2.2 tabs/dropzone | ✅ |
+| C9 | Sync simple-git: corpus-writer, commit-queue, APIs commit/sync-status, CommitQueue UI | ✅ |
 
 ### En rama activa: `claude/admin-screenshot-dashboard-zKGaF`
 
-C7 subido, PR #82 abierto. Pendiente merge.
+C10 en progreso: wiring CommitQueue en corpus page (cola colapsable), stubs mejorados.
 
-Fixes de accesibilidad y HTML en C8 (este commit):
-- Skip-to-main link en root layout
-- Admin layout: `<nav>` con `aria-current="page"` + roving tabindex
-- Login page: passkey authentication wired (antes era botón estático)
-- FileDropzone: `role="button"` + `tabIndex` + `onKeyDown` (Enter/Space)
-- AnalysisPanel tabs: arrow key navigation (WCAG 2.2 pattern)
-- DB schema: índice en `estado_codificacion`
-- DB init: auto-cleanup de challenges expirados en cold start
+### Próximo (F4 — no comenzado)
 
-### Próximo (F3)
+- C11: Kanban GT (`/codificacion`) — columnas open/axial/selective con drag entre estados
+- C12: Preview force graph d3 (`/grafo`)
+- C13: Export consolidado del corpus
 
-- C9: `lib/git/` — simple-git: copiar archivos al corpus-repo, git add + commit local
-- C10: Cola de commits en SQLite + UI de aprobación
-- C11: Polling `git log origin/main` → marcar drafts como `synced`
+### Stubs activos
 
-### Stubs activos (F4 — no comenzado)
-
-- `/codificacion` — Kanban GT
-- `/grafo` — Preview force graph d3
+- `/codificacion` — placeholder semántico (sin Kanban todavía)
+- `/grafo` — placeholder semántico (sin d3 todavía)
 
 ---
 

--- a/terraza/src/app/(admin)/codificacion/page.tsx
+++ b/terraza/src/app/(admin)/codificacion/page.tsx
@@ -1,8 +1,11 @@
 export default function CodificacionPage(): React.ReactElement {
   return (
     <div>
-      <h1 className="text-3xl font-bold mb-4">Codificación Grounded Theory</h1>
-      <p className="text-gray-600 dark:text-gray-400">Próximamente en F4</p>
+      <h1 className="text-3xl font-bold mb-2 text-gray-900">Codificación Grounded Theory</h1>
+      <p className="text-gray-500 text-sm mb-6">Kanban open → axial → selective — F4</p>
+      <div className="p-8 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-center text-sm text-gray-400">
+        Kanban GT pendiente de implementación
+      </div>
     </div>
   );
 }

--- a/terraza/src/app/(admin)/corpus/page.tsx
+++ b/terraza/src/app/(admin)/corpus/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { CaptureCard } from '@/components/organisms/CaptureCard';
 import { AnalysisPanel } from '@/components/organisms/AnalysisPanel';
+import { CommitQueue } from '@/components/organisms/CommitQueue';
 import { Spinner } from '@/components/atoms/Spinner';
 import type { UploadRecord } from '@/lib/db/uploads';
 
@@ -11,6 +12,7 @@ export default function CorpusPage(): React.ReactElement {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showQueue, setShowQueue] = useState(false);
 
   const fetchUploads = useCallback(async () => {
     try {
@@ -36,6 +38,11 @@ export default function CorpusPage(): React.ReactElement {
     void fetchUploads();
   };
 
+  const handleCommitted = () => {
+    void fetchUploads();
+    setShowQueue(true);
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64" aria-busy="true">
@@ -47,7 +54,7 @@ export default function CorpusPage(): React.ReactElement {
 
   if (error) {
     return (
-      <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-800">
+      <div role="alert" className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-800">
         {error}
       </div>
     );
@@ -55,32 +62,57 @@ export default function CorpusPage(): React.ReactElement {
 
   return (
     <div className="flex gap-6 h-[calc(100vh-8rem)]">
-      {/* Left: capture list */}
-      <aside className="w-80 shrink-0 overflow-y-auto" aria-label="Lista de capturas">
+      {/* Left: capture list + commit queue */}
+      <aside className="w-80 shrink-0 flex flex-col overflow-hidden" aria-label="Lista de capturas">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl font-bold text-gray-900">Corpus</h1>
           <span className="text-sm text-gray-500">{uploads.length} capturas</span>
         </div>
 
-        {uploads.length === 0 ? (
-          <p className="text-sm text-gray-500 text-center py-8">
-            Aún no hay capturas. Sube la primera desde{' '}
-            <a href="/upload" className="text-blue-600 hover:underline">Subir captura</a>.
-          </p>
-        ) : (
-          <ul className="space-y-3" aria-label="Capturas del corpus">
-            {uploads.map((upload) => (
-              <li key={upload.id}>
-                <CaptureCard
-                  upload={upload}
-                  isSelected={selectedId === upload.id}
-                  onSelect={setSelectedId}
-                  onAnalyzed={handleAnalyzed}
-                />
-              </li>
-            ))}
-          </ul>
-        )}
+        {/* Capture list — scrollable */}
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {uploads.length === 0 ? (
+            <p className="text-sm text-gray-500 text-center py-8">
+              Aún no hay capturas. Sube la primera desde{' '}
+              <a href="/upload" className="text-accent-700 hover:underline">Subir captura</a>.
+            </p>
+          ) : (
+            <ul className="space-y-3 pb-4" aria-label="Capturas del corpus">
+              {uploads.map((upload) => (
+                <li key={upload.id}>
+                  <CaptureCard
+                    upload={upload}
+                    isSelected={selectedId === upload.id}
+                    onSelect={setSelectedId}
+                    onAnalyzed={handleAnalyzed}
+                    onCommitted={handleCommitted}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Commit queue — collapsible section */}
+        <div className="border-t border-gray-200 pt-3 mt-3 shrink-0">
+          <button
+            type="button"
+            onClick={() => setShowQueue((v) => !v)}
+            aria-expanded={showQueue}
+            aria-controls="commit-queue-panel"
+            className="flex items-center justify-between w-full text-sm font-medium text-gray-700 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2"
+          >
+            <span>Cola de commits</span>
+            <span aria-hidden="true" className="text-gray-400">
+              {showQueue ? '▲' : '▼'}
+            </span>
+          </button>
+          {showQueue && (
+            <div id="commit-queue-panel" className="mt-3">
+              <CommitQueue />
+            </div>
+          )}
+        </div>
       </aside>
 
       {/* Right: analysis panel */}

--- a/terraza/src/app/(admin)/grafo/page.tsx
+++ b/terraza/src/app/(admin)/grafo/page.tsx
@@ -1,8 +1,11 @@
 export default function GrafoPage(): React.ReactElement {
   return (
     <div>
-      <h1 className="text-3xl font-bold mb-4">Grafo</h1>
-      <p className="text-gray-600 dark:text-gray-400">Próximamente en F4</p>
+      <h1 className="text-3xl font-bold mb-2 text-gray-900">Grafo de correlaciones</h1>
+      <p className="text-gray-500 text-sm mb-6">Preview d3-force del contra-archivo — F4</p>
+      <div className="p-8 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-center text-sm text-gray-400">
+        Force graph pendiente de implementación
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **`/corpus` page**: `CommitQueue` integrado como sección colapsable al pie de la sidebar — se abre automáticamente tras el primer commit de una captura; `aria-expanded` + `aria-controls` para accesibilidad
- **Stubs mejorados**: `/codificacion` y `/grafo` tienen mensajes descriptivos en lugar de texto genérico
- **CLAUDE.md**: estado del proyecto actualizado — C1–C9 merged en main, F4 pendiente

## Test plan

- [ ] Navegar a `/corpus`, subir y analizar una captura, presionar "Commitear al repo" → la cola debe desplegarse automáticamente
- [ ] Verificar que toggle "Cola de commits" funciona con teclado (Enter/Space)
- [ ] Navegar a `/codificacion` y `/grafo` — deben mostrar mensajes descriptivos
- [ ] `tsc --noEmit` limpio

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_