### PR TITLE
fix(a11y): dark mode en headings de stubs codificacion y grafo

### DIFF
--- a/terraza/src/app/(admin)/codificacion/page.tsx
+++ b/terraza/src/app/(admin)/codificacion/page.tsx
@@ -1,8 +1,8 @@
 export default function CodificacionPage(): React.ReactElement {
   return (
     <div>
-      <h1 className="text-3xl font-bold mb-2 text-gray-900">Codificación Grounded Theory</h1>
-      <p className="text-gray-500 text-sm mb-6">Kanban open → axial → selective — F4</p>
+      <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Codificación Grounded Theory</h1>
+      <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">Kanban open → axial → selective — F4</p>
       <div className="p-8 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-center text-sm text-gray-400">
         Kanban GT pendiente de implementación
       </div>

--- a/terraza/src/app/(admin)/grafo/page.tsx
+++ b/terraza/src/app/(admin)/grafo/page.tsx
@@ -1,8 +1,8 @@
 export default function GrafoPage(): React.ReactElement {
   return (
     <div>
-      <h1 className="text-3xl font-bold mb-2 text-gray-900">Grafo de correlaciones</h1>
-      <p className="text-gray-500 text-sm mb-6">Preview d3-force del contra-archivo — F4</p>
+      <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Grafo de correlaciones</h1>
+      <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">Preview d3-force del contra-archivo — F4</p>
       <div className="p-8 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-center text-sm text-gray-400">
         Force graph pendiente de implementación
       </div>


### PR DESCRIPTION
## Summary

- Añade `dark:text-white` y `dark:text-gray-400` en `/codificacion` y `/grafo`
- Corrige regresión introducida en C10: `text-gray-900` sin variante dark → contraste insuficiente sobre `dark:bg-gray-950`
- Detectado por Codex review (P2) en PR #84

## Test plan

- [ ] Activar dark mode del sistema → verificar headings legibles en `/codificacion` y `/grafo`

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_