### PR TITLE
feat(grafo): C12 — force graph preview + export consolidado

### DIFF
--- a/terraza/src/app/(admin)/grafo/page.tsx
+++ b/terraza/src/app/(admin)/grafo/page.tsx
@@ -1,11 +1,98 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { ForceGraph } from '@/components/organisms/ForceGraph';
+import { Spinner } from '@/components/atoms/Spinner';
+import type { GraphData } from '@/app/api/corpus/graph-data/route';
+
 export default function GrafoPage(): React.ReactElement {
+  const [data, setData] = useState<GraphData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/corpus/graph-data');
+        if (!res.ok) throw new Error('No se pudo cargar el grafo');
+        const json = await res.json() as GraphData;
+        setData(json);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error de carga');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void load();
+  }, []);
+
+  const handleExport = () => {
+    const a = document.createElement('a');
+    a.href = '/api/corpus/export';
+    a.download = `corpus-export-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+  };
+
   return (
-    <div>
-      <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Grafo de correlaciones</h1>
-      <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">Preview d3-force del contra-archivo — F4</p>
-      <div className="p-8 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-center text-sm text-gray-400">
-        Force graph pendiente de implementación
+    <div className="flex flex-col h-[calc(100vh-4rem)]">
+      <div className="mb-4 flex items-end justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Grafo de correlaciones
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            Nodos = capturas · aristas = tags compartidos · tamaño = estado GT
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {data && (
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {data.nodes.length} nodos · {data.edges.length} aristas
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleExport}
+            className="text-sm px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            aria-label="Exportar corpus completo como JSON"
+          >
+            Exportar corpus
+          </button>
+        </div>
       </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center flex-1 gap-3" aria-busy="true">
+          <Spinner size="md" />
+          <span className="text-sm text-gray-500 dark:text-gray-400">Construyendo grafo…</span>
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="p-4 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg text-red-800 dark:text-red-300 text-sm"
+        >
+          {error}
+        </div>
+      )}
+
+      {data && !isLoading && data.nodes.length === 0 && (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center text-sm text-gray-500 dark:text-gray-400">
+            <p className="mb-2">No hay capturas con tags para mostrar en el grafo.</p>
+            <a href="/corpus" className="text-accent-700 hover:underline">
+              Añadir tags en el corpus →
+            </a>
+          </div>
+        </div>
+      )}
+
+      {data && !isLoading && data.nodes.length > 0 && (
+        <div className="flex-1 min-h-0 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden bg-white dark:bg-gray-950">
+          <ForceGraph nodes={data.nodes} edges={data.edges} />
+        </div>
+      )}
     </div>
   );
 }

--- a/terraza/src/app/api/corpus/export/route.ts
+++ b/terraza/src/app/api/corpus/export/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { getUploadsByUserId } from '@/lib/db/uploads';
+import { CASOS } from '@/lib/corpus/cases';
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const uploads = getUploadsByUserId(session.userId, 500);
+
+    const exported = uploads.map((u) => {
+      const caso = Object.values(CASOS).find((c) => c.id === u.casoId);
+      const tags = u.tags ? (JSON.parse(u.tags) as string[]) : [];
+
+      let codes: unknown = null;
+      let mistranslations: unknown = null;
+
+      try { if (u.codes) codes = JSON.parse(u.codes); } catch { /* malformed */ }
+      try { if (u.mistranslations) mistranslations = JSON.parse(u.mistranslations); } catch { /* malformed */ }
+
+      return {
+        id: u.id,
+        caso: u.casoId,
+        casoLabel: caso?.label ?? '',
+        casoSlug: caso?.slug ?? '',
+        fileName: u.fileName,
+        fileType: u.fileType,
+        hashSource: u.hashSource,
+        fuenteTipo: u.fuenteTipo,
+        regimenVerdad: u.regimenVerdad,
+        estadoCodificacion: u.estadoCodificacion,
+        tags,
+        fechaEvento: u.fechaEvento,
+        fechaCaptura: new Date(u.createdAt).toISOString(),
+        transcription: u.transcription,
+        codes,
+        mistranslations,
+      };
+    });
+
+    const payload = JSON.stringify({ exportedAt: new Date().toISOString(), total: exported.length, corpus: exported }, null, 2);
+
+    return new NextResponse(payload, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="corpus-export-${new Date().toISOString().slice(0, 10)}.json"`,
+      },
+    });
+  } catch (error) {
+    console.error('export error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/terraza/src/app/api/corpus/graph-data/route.ts
+++ b/terraza/src/app/api/corpus/graph-data/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { getUploadsByUserId } from '@/lib/db/uploads';
+import { CASOS } from '@/lib/corpus/cases';
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  casoId: 1 | 2 | 3 | 4;
+  casoSlug: string;
+  regimenVerdad: string;
+  fuenteTipo: string;
+  estadoCodificacion: string;
+  tags: string[];
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  weight: number; // shared tags count
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const uploads = getUploadsByUserId(session.userId, 200);
+
+    const nodes: GraphNode[] = uploads.map((u) => {
+      const caso = Object.values(CASOS).find((c) => c.id === u.casoId);
+      const tags = u.tags ? (JSON.parse(u.tags) as string[]) : [];
+      return {
+        id: u.id,
+        label: u.fileName,
+        casoId: u.casoId,
+        casoSlug: caso?.slug ?? `caso-${u.casoId}`,
+        regimenVerdad: u.regimenVerdad,
+        fuenteTipo: u.fuenteTipo,
+        estadoCodificacion: u.estadoCodificacion,
+        tags,
+      };
+    });
+
+    // Edges: connect nodes that share at least one tag
+    const edges: GraphEdge[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const a = nodes[i];
+        const b = nodes[j];
+        const shared = a.tags.filter((t) => b.tags.includes(t));
+        if (shared.length > 0) {
+          edges.push({ source: a.id, target: b.id, weight: shared.length });
+        }
+      }
+    }
+
+    return NextResponse.json({ nodes, edges });
+  } catch (error) {
+    console.error('graph-data error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/terraza/src/components/organisms/ForceGraph.tsx
+++ b/terraza/src/components/organisms/ForceGraph.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { GraphNode, GraphEdge } from '@/app/api/corpus/graph-data/route';
+
+interface SimNode extends GraphNode {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+const CASO_COLORS: Record<number, string> = {
+  1: '#3b82f6', // blue
+  2: '#10b981', // emerald
+  3: '#f59e0b', // amber
+  4: '#8b5cf6', // violet
+};
+
+const ESTADO_RADIUS: Record<string, number> = {
+  pendiente: 6,
+  open: 8,
+  axial: 10,
+  selective: 12,
+  verificado: 14,
+};
+
+function runSimulation(nodes: SimNode[], edges: GraphEdge[], width: number, height: number): () => void {
+  const cx = width / 2;
+  const cy = height / 2;
+  let frame: number;
+
+  function tick() {
+    // Repulsion between all node pairs
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const dx = nodes[j].x - nodes[i].x;
+        const dy = nodes[j].y - nodes[i].y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        const force = 1500 / (dist * dist);
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        nodes[i].vx -= fx;
+        nodes[i].vy -= fy;
+        nodes[j].vx += fx;
+        nodes[j].vy += fy;
+      }
+    }
+
+    // Attraction along edges
+    for (const edge of edges) {
+      const a = nodes.find((n) => n.id === edge.source);
+      const b = nodes.find((n) => n.id === edge.target);
+      if (!a || !b) continue;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const target = 80 * (1 / edge.weight);
+      const force = (dist - target) * 0.05;
+      const fx = (dx / dist) * force;
+      const fy = (dy / dist) * force;
+      a.vx += fx;
+      a.vy += fy;
+      b.vx -= fx;
+      b.vy -= fy;
+    }
+
+    // Gravity toward center
+    for (const node of nodes) {
+      node.vx += (cx - node.x) * 0.002;
+      node.vy += (cy - node.y) * 0.002;
+
+      // Damping
+      node.vx *= 0.85;
+      node.vy *= 0.85;
+
+      node.x += node.vx;
+      node.y += node.vy;
+
+      // Boundary
+      const r = ESTADO_RADIUS[node.estadoCodificacion] ?? 8;
+      node.x = Math.max(r + 4, Math.min(width - r - 4, node.x));
+      node.y = Math.max(r + 4, Math.min(height - r - 4, node.y));
+    }
+
+    frame = requestAnimationFrame(tick);
+  }
+
+  frame = requestAnimationFrame(tick);
+  return () => cancelAnimationFrame(frame);
+}
+
+interface ForceGraphProps {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export function ForceGraph({ nodes: rawNodes, edges }: ForceGraphProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [simNodes, setSimNodes] = useState<SimNode[]>([]);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [dims, setDims] = useState({ w: 800, h: 500 });
+
+  // Initialize positions
+  useEffect(() => {
+    const w = svgRef.current?.clientWidth ?? 800;
+    const h = svgRef.current?.clientHeight ?? 500;
+    setDims({ w, h });
+
+    const initialized: SimNode[] = rawNodes.map((n, i) => ({
+      ...n,
+      x: w / 2 + Math.cos((i / rawNodes.length) * Math.PI * 2) * 120,
+      y: h / 2 + Math.sin((i / rawNodes.length) * Math.PI * 2) * 120,
+      vx: 0,
+      vy: 0,
+    }));
+    setSimNodes(initialized);
+  }, [rawNodes]);
+
+  // Run physics simulation
+  useEffect(() => {
+    if (simNodes.length === 0) return;
+
+    // Snapshot so the simulation mutates in place without triggering re-renders on every tick
+    const nodesSnapshot = simNodes;
+
+    let ticks = 0;
+    const MAX_TICKS = 300;
+    const stop = runSimulation(nodesSnapshot, edges, dims.w, dims.h);
+
+    const interval = setInterval(() => {
+      ticks++;
+      // Force a re-render every 10 ticks to show animation
+      setSimNodes([...nodesSnapshot]);
+      if (ticks >= MAX_TICKS) {
+        clearInterval(interval);
+        stop();
+      }
+    }, 16);
+
+    return () => {
+      clearInterval(interval);
+      stop();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [simNodes.length, edges, dims]);
+
+  const hovered = hoveredId ? simNodes.find((n) => n.id === hoveredId) : null;
+
+  return (
+    <div className="relative w-full h-full">
+      <svg
+        ref={svgRef}
+        className="w-full h-full"
+        aria-label="Grafo de correlaciones del corpus"
+        role="img"
+      >
+        {/* Edges */}
+        {edges.map((e) => {
+          const a = simNodes.find((n) => n.id === e.source);
+          const b = simNodes.find((n) => n.id === e.target);
+          if (!a || !b) return null;
+          const isHighlighted = hoveredId === e.source || hoveredId === e.target;
+          return (
+            <line
+              key={`${e.source}-${e.target}`}
+              x1={a.x} y1={a.y}
+              x2={b.x} y2={b.y}
+              stroke={isHighlighted ? '#6366f1' : '#d1d5db'}
+              strokeWidth={isHighlighted ? e.weight * 1.5 : e.weight * 0.8}
+              strokeOpacity={isHighlighted ? 0.8 : 0.4}
+            />
+          );
+        })}
+
+        {/* Nodes */}
+        {simNodes.map((node) => {
+          const r = ESTADO_RADIUS[node.estadoCodificacion] ?? 8;
+          const color = CASO_COLORS[node.casoId] ?? '#6b7280';
+          const isHovered = hoveredId === node.id;
+          return (
+            <g
+              key={node.id}
+              transform={`translate(${node.x},${node.y})`}
+              onMouseEnter={() => setHoveredId(node.id)}
+              onMouseLeave={() => setHoveredId(null)}
+              style={{ cursor: 'pointer' }}
+              aria-label={`${node.label} — ${node.estadoCodificacion}`}
+            >
+              <circle
+                r={isHovered ? r + 3 : r}
+                fill={color}
+                fillOpacity={isHovered ? 1 : 0.8}
+                stroke="#fff"
+                strokeWidth={isHovered ? 2 : 1}
+              />
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Tooltip */}
+      {hovered && (
+        <div
+          className="absolute bottom-4 left-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-3 text-xs shadow-lg max-w-xs pointer-events-none"
+          aria-live="polite"
+        >
+          <p className="font-semibold text-gray-900 dark:text-white truncate">{hovered.label}</p>
+          <p className="text-gray-500 dark:text-gray-400 mt-0.5">{hovered.regimenVerdad} · {hovered.fuenteTipo}</p>
+          <p className="text-gray-500 dark:text-gray-400">{hovered.estadoCodificacion}</p>
+          {hovered.tags.length > 0 && (
+            <p className="text-gray-400 dark:text-gray-500 mt-1 truncate">
+              {hovered.tags.join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="absolute top-4 right-4 bg-white/90 dark:bg-gray-900/90 border border-gray-200 dark:border-gray-700 rounded-lg p-3 text-xs space-y-1.5">
+        <p className="font-semibold text-gray-700 dark:text-gray-300 mb-2">Casos</p>
+        {Object.entries(CASO_COLORS).map(([id, color]) => (
+          <div key={id} className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full shrink-0" style={{ backgroundColor: color }} />
+            <span className="text-gray-600 dark:text-gray-400">Caso {id}</span>
+          </div>
+        ))}
+        <p className="font-semibold text-gray-700 dark:text-gray-300 mt-2 mb-1">Tamaño = estado GT</p>
+        <p className="text-gray-500 dark:text-gray-500">pequeño → open · grande → verificado</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumen

- **`/api/corpus/graph-data`** — construye nodos (una captura = un nodo) y aristas (pares con al menos un tag compartido, peso = número de tags compartidos)
- **`/api/corpus/export`** — descarga JSON completo del corpus con `Content-Disposition: attachment`
- **`ForceGraph` organism** — simulación spring con `requestAnimationFrame`, sin dependencia d3; SVG puro con React. Colores por `casoId`, radio por `estadoCodificación`, tooltip en hover, leyenda integrada.
- **Página `/grafo`** — cliente que carga `graph-data`, muestra stats (nodos/aristas), botón de exportar corpus, y renderiza `<ForceGraph>` en un contenedor full-height

## Plan de pruebas

- [ ] Subir capturas con tags solapados → verificar aristas en grafo
- [ ] Hover sobre nodo → tooltip muestra fileName, regimenVerdad, estadoCodificación, tags
- [ ] Nodos coloreados por caso (azul/esmeralda/ámbar/violeta)
- [ ] Nodos se animan durante 300 ticks (≈5 s) hasta estabilizarse
- [ ] Botón "Exportar corpus" descarga archivo JSON con nombre fecha-hoy
- [ ] Estado vacío (sin capturas con tags) muestra mensaje y enlace a /corpus
- [ ] `tsc --noEmit` pasa sin errores

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_