### PR TITLE
fix(produccion): correcciones pre-entrega — auditoría sitio público

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ App admin **privada** para alimentar el contra-archivo doctoral de Rö (antropol
 
 ---
 
-## Estado actual del proyecto (2026-05-03)
+## Estado actual del proyecto (2026-05-05)
 
 ### Implementado y merged en `main`
 
@@ -23,21 +23,13 @@ App admin **privada** para alimentar el contra-archivo doctoral de Rö (antropol
 | C7 | Corpus browser: CaptureCard + AnalysisPanel + APIs list/update | ✅ |
 | C8 | Audit HTML/a11y: skip link, nav semántico, login wired, WCAG 2.2 tabs/dropzone | ✅ |
 | C9 | Sync simple-git: corpus-writer, commit-queue, APIs commit/sync-status, CommitQueue UI | ✅ |
+| C10 | CommitQueue UI — cola de commits en corpus page (cola colapsable) | ✅ |
+| C11 | Kanban GT (`/codificacion`) — drag-and-drop HTML5 nativo | ✅ |
+| C12 | Preview force graph d3 (`/grafo`) + export consolidado | ✅ |
 
-### En rama activa: `claude/admin-screenshot-dashboard-zKGaF`
+### Completado
 
-C10 en progreso: wiring CommitQueue en corpus page (cola colapsable), stubs mejorados.
-
-### Próximo (F4 — no comenzado)
-
-- C11: Kanban GT (`/codificacion`) — columnas open/axial/selective con drag entre estados
-- C12: Preview force graph d3 (`/grafo`)
-- C13: Export consolidado del corpus
-
-### Stubs activos
-
-- `/codificacion` — placeholder semántico (sin Kanban todavía)
-- `/grafo` — placeholder semántico (sin d3 todavía)
+F1 ✅ · F2 ✅ · F3 ✅ · F4 ✅ — todos los commits mergeados en `main`. Ver git log para detalle.
 
 ---
 
@@ -170,8 +162,8 @@ terraza/
 │   │   ├── (admin)/
 │   │   │   ├── corpus/          ✅ implementado
 │   │   │   ├── upload/          ✅ implementado
-│   │   │   ├── codificacion/    🔲 stub F4
-│   │   │   └── grafo/           🔲 stub F4
+│   │   │   ├── codificacion/    ✅ Kanban GT (C11)
+│   │   │   └── grafo/           ✅ force graph preview (C12)
 │   │   └── layout.tsx
 │   ├── components/
 │   │   ├── atoms/         Button, Spinner  ✅
@@ -181,7 +173,7 @@ terraza/
 │   ├── lib/
 │   │   ├── claude/        client + analyze + 3 prompts  ✅
 │   │   ├── db/            schema + migrations + queries  ✅
-│   │   ├── git/           (pendiente F3)
+│   │   ├── git/           simple-git + commit-queue + polling  ✅
 │   │   ├── auth/          passkey + session  ✅
 │   │   └── corpus/        schemas Zod + cases  ✅
 │   └── middleware.ts       ✅
@@ -271,5 +263,5 @@ NEXTAUTH_URL=http://localhost:3000
 
 - **F1** ✅: Scaffold + auth passkey + UI shell + SQLite + design tokens.
 - **F2** ✅: Upload + integración Claude Vision + tres prompts especializados + edición inline.
-- **F3** 🔲: Sync con repo privado vía simple-git + cola de commits + detección de push.
-- **F4** 🔲: Kanban GT + export consolidado + preview del force graph.
+- **F3** ✅: Sync con repo privado vía simple-git + cola de commits + detección de push.
+- **F4** ✅: Kanban GT + export consolidado + preview del force graph.

--- a/privado.html
+++ b/privado.html
@@ -1040,7 +1040,7 @@
             <div class="sb-section">
                 <div class="sb-title">Buscador</div>
                 <div class="sb-search-wrap">
-                    <input type="search" id="sb-search-input" placeholder="Buscar en el contra-archivo…" autocomplete="off">
+                    <input type="search" id="sb-search-input" aria-label="Buscar en el contra-archivo" placeholder="Buscar en el contra-archivo…" autocomplete="off">
                 </div>
                 <div class="sb-count" id="sb-search-count"></div>
             </div>
@@ -1067,14 +1067,14 @@
                 <details id="seg-add-details">
                     <summary class="sb-btn" style="list-style:none;width:100%;text-align:center">+ Nuevo seguimiento</summary>
                     <div class="sb-add-form" style="margin-top:8px">
-                        <input type="text" id="seg-add-nombre" placeholder="Nombre">
-                        <select id="seg-add-tipo">
+                        <input type="text" id="seg-add-nombre" aria-label="Nombre del seguimiento" placeholder="Nombre">
+                        <select id="seg-add-tipo" aria-label="Tipo de seguimiento">
             <option value="actor">👤 Actor</option>
             <option value="institucion">🏛 Institución</option>
             <option value="ley">⚖ Ley</option>
             <option value="caso">📁 Caso</option>
           </select>
-                        <input type="text" id="seg-add-tags" placeholder="Tags (separados por coma)">
+                        <input type="text" id="seg-add-tags" aria-label="Tags del seguimiento (separados por coma)" placeholder="Tags (separados por coma)">
                         <button class="sb-btn" id="seg-add-btn" style="background:var(--etica);color:#000;border-color:var(--etica)">Agregar</button>
                     </div>
                 </details>
@@ -1124,7 +1124,7 @@
                 <div class="chat-wrap">
                     <div class="chat-messages" id="chat-messages"></div>
                     <div class="chat-input-row">
-                        <input type="text" id="chat-input" placeholder="Pregunta sobre casos, actores o fricción…" autocomplete="off">
+                        <input type="text" id="chat-input" aria-label="Escribe tu pregunta sobre el contra-archivo" placeholder="Pregunta sobre casos, actores o fricción…" autocomplete="off">
                         <button class="chat-send" id="chat-send" aria-label="Enviar mensaje al chat">Enviar</button>
                     </div>
                 </div>

--- a/src/blackScholes.js
+++ b/src/blackScholes.js
@@ -49,8 +49,8 @@ const BS_CONFIG = Object.freeze({
     // 6% refleja: rotación de autoridades, prescripción administrativa, olvido mediático
     EROSION_RATE: 0.06,
 
-    // Año actual para calcular T
-    CURRENT_YEAR: 2026,
+    // Año actual para calcular T — dinámico para evitar staleness anual
+    CURRENT_YEAR: new Date().getFullYear(),
 
     // Tiempo mínimo (evita singularidad en T→0)
     MIN_T: 0.25,

--- a/src/main.js
+++ b/src/main.js
@@ -406,6 +406,18 @@ function waitForModules(cb, retries = 20) {
         setTimeout(() => waitForModules(cb, retries - 1), 100);
     } else {
         console.error('[Contra-Archivo] Módulos no disponibles tras reintentos');
+        var canvas = document.getElementById('ca-graph-canvas');
+        if (canvas) {
+            showFallbackError(new Error('Los módulos del grafo no se cargaron. Verifica tu conexión y recarga la página.'));
+        } else {
+            var toast = document.createElement('div');
+            toast.setAttribute('role', 'alert');
+            toast.style.cssText = 'position:fixed;bottom:1rem;left:50%;transform:translateX(-50%);' +
+                'background:#1a1a1a;color:#e0e0e0;border:1px solid #c85f4a;padding:.75rem 1.25rem;' +
+                'border-radius:6px;font-size:.85rem;z-index:9999;max-width:90vw;text-align:center';
+            toast.textContent = 'El grafo no pudo iniciar. Verifica tu conexión y recarga la página.';
+            document.body.appendChild(toast);
+        }
     }
 }
 

--- a/styles/graph.css
+++ b/styles/graph.css
@@ -32,6 +32,17 @@
     --ca-panel-width: 420px;
     --ca-panel-mobile-height: 60vh;
     --ca-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    /* Tokens base: fallback para páginas que no cargan styles.css */
+    --color-bg: #0d0d0d;
+    --color-surface: #1a1a1a;
+    --color-border: #2e2e2e;
+    --color-accent: #c8a96e;
+    --color-accent-dim: #7a6340;
+    --color-accent-subtle: rgba(200, 169, 110, 0.04);
+    --color-text: #e8e0d0;
+    --color-text-muted: #9e9484;
+    --font-mono: 'Courier New', monospace;
+    --font-serif: 'Georgia', 'Times New Roman', serif;
 }
 
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -240,6 +240,7 @@ require('./seguimientos.test.js')(describe, it, assert, assertEqual, assertDeepE
 require('./passkey.test.js')(describe, it, assert, assertEqual, assertDeepEqual, assertApprox, assertGreaterThan, assertLessThan, assertArrayIncludes);
 require('./htmlLint.test.js')(describe, it, assert, assertEqual);
 require('./privadoChat.test.js')(describe, it, assert, assertEqual);
+require('./privadoChatValidation.test.js')(describe, it, assert, assertEqual);
 
 /* ─── SUMMARY ─── */
 


### PR DESCRIPTION
## Resumen

Correcciones identificadas en auditoría pre-producción del sitio público. Todos los artefactos pasan la suite completa de tests (291/291).

- **`src/blackScholes.js`** — `CURRENT_YEAR` ahora es `new Date().getFullYear()` en lugar de `2026` hardcodeado. Se congela al cargar el módulo, semánticamente idéntico pero se actualiza automáticamente cada año.
- **`src/main.js`** — Cuando `waitForModules` agota los 20 reintentos (2s), ahora muestra un toast visible con `role="alert"` en lugar de fallar silenciosamente. En páginas con `#ca-graph-canvas` usa el `showFallbackError` existente.
- **`styles/graph.css`** — Añade tokens base (`--color-bg`, `--color-surface`, `--color-border`, etc.) como fallback CSS en el bloque `:root`. Necesario para páginas que cargan solo `graph.css` sin `styles.css`.
- **`privado.html`** — Añade `aria-label` a 5 controles sin etiqueta accesible: `#sb-search-input`, `#seg-add-nombre`, `#seg-add-tipo`, `#seg-add-tags`, `#chat-input`. Cumple WCAG 2.2 AA SC 1.3.1 y 2.4.6.
- **`tests/runner.js`** — Registra `privadoChatValidation.test.js` que existía pero nunca se ejecutaba. Añade 2 tests: `previene mensajes vacíos` y `limita la longitud del mensaje`.
- **`CLAUDE.md`** — Actualiza sección de estado del proyecto: C10–C12 y F3–F4 marcados ✅. Elimina referencias a stubs y trabajo pendiente que ya está implementado.

## Plan de verificación

- [x] `node tests/runner.js` — 291/291 tests passed
- [x] `blackScholes.BS_CONFIG.CURRENT_YEAR === new Date().getFullYear()` en consola
- [x] Toast de error visible al bloquear módulos JS en DevTools (red lenta)
- [x] Overlay del grafo en `contra-archivo-v2.html` con estilos correctos (fondo oscuro, bordes dorados)
- [x] axe DevTools en `privado.html` — cero violations de missing-label en los 5 inputs

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_