### PR TITLE
feat(dashboard): bottom nav persistente — 4 secciones del corpus admin

### DIFF
--- a/terraza/src/app/(admin)/layout.tsx
+++ b/terraza/src/app/(admin)/layout.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { BottomNav } from '@/components/molecules/BottomNav';
 
 const NAV_LINKS = [
   { href: '/corpus', label: 'Corpus' },
@@ -9,17 +11,17 @@ const NAV_LINKS = [
   { href: '/grafo', label: 'Grafo' },
 ];
 
-function AdminNav() {
+function SidebarNav() {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="Navegación principal">
+    <nav aria-label="Navegación lateral">
       <ul className="space-y-1" role="list">
         {NAV_LINKS.map(({ href, label }) => {
           const isActive = pathname === href || pathname.startsWith(href + '/');
           return (
             <li key={href}>
-              <a
+              <Link
                 href={href}
                 aria-current={isActive ? 'page' : undefined}
                 className={`
@@ -32,7 +34,7 @@ function AdminNav() {
                 `}
               >
                 {label}
-              </a>
+              </Link>
             </li>
           );
         })}
@@ -48,18 +50,28 @@ export default function AdminLayout({
 }): React.ReactElement {
   return (
     <div className="flex min-h-screen bg-white dark:bg-gray-950">
+      {/* Sidebar — visible solo en md+ */}
       <aside
-        className="w-64 shrink-0 border-r border-gray-200 dark:border-gray-800 p-4 flex flex-col"
+        className="hidden md:flex w-64 shrink-0 border-r border-gray-200 dark:border-gray-800 p-4 flex-col"
         aria-label="Barra lateral"
       >
         <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider px-4 mb-3">
           Contra-archivo
         </p>
-        <AdminNav />
+        <SidebarNav />
       </aside>
-      <main id="main-content" className="flex-1 p-8 min-w-0" tabIndex={-1}>
+
+      {/* Contenido principal — padding-bottom en mobile para el bottom nav */}
+      <main
+        id="main-content"
+        className="flex-1 p-4 md:p-8 min-w-0 pb-20 md:pb-8"
+        tabIndex={-1}
+      >
         {children}
       </main>
+
+      {/* Bottom nav — persiste en todas las páginas del dashboard */}
+      <BottomNav />
     </div>
   );
 }

--- a/terraza/src/components/molecules/BottomNav.tsx
+++ b/terraza/src/components/molecules/BottomNav.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_ITEMS = [
+  {
+    href: '/corpus',
+    label: 'Corpus',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+      </svg>
+    ),
+  },
+  {
+    href: '/upload',
+    label: 'Subir',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="17 8 12 3 7 8" />
+        <line x1="12" y1="3" x2="12" y2="15" />
+      </svg>
+    ),
+  },
+  {
+    href: '/codificacion',
+    label: 'Codificación',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="3" y="3" width="5" height="18" rx="1" />
+        <rect x="10" y="3" width="5" height="12" rx="1" />
+        <rect x="17" y="3" width="5" height="8" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    href: '/grafo',
+    label: 'Grafo',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <circle cx="18" cy="5" r="3" />
+        <circle cx="6" cy="12" r="3" />
+        <circle cx="18" cy="19" r="3" />
+        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+      </svg>
+    ),
+  },
+] as const;
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Navegación principal"
+      className="fixed bottom-0 inset-x-0 z-40 border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 safe-area-bottom"
+    >
+      <ul role="list" className="flex h-16">
+        {NAV_ITEMS.map(({ href, label, icon }) => {
+          const isActive = pathname === href || pathname.startsWith(href + '/');
+          return (
+            <li key={href} className="flex-1">
+              <Link
+                href={href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`
+                  flex flex-col items-center justify-center gap-1 h-full w-full
+                  text-[10px] font-medium tracking-wide transition-colors
+                  focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent-600
+                  ${isActive
+                    ? 'text-accent-600 dark:text-accent-400'
+                    : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+                  }
+                `}
+              >
+                <span className={`transition-transform ${isActive ? 'scale-110' : ''}`}>
+                  {icon}
+                </span>
+                <span>{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Bottom Nav persistente en el dashboard admin

### Qué hace
- `BottomNav` — molécula nueva con 4 botones de navegación que persiste en todas las páginas del dashboard
- Se renderiza en el layout admin, por encima del contenido, fijo al fondo de pantalla

### Las 4 secciones
| Icono | Sección | Ruta |
|-------|---------|------|
| 📚 Archivo | Corpus | `/corpus` |
| ↑ Flecha | Subir | `/upload` |
| ☰ Columnas | Codificación | `/codificacion` |
| ◦─◦ Red | Grafo | `/grafo` |

### A11y
- `aria-current="page"` en item activo
- `aria-label="Navegación principal"` en `<nav>`
- `role="list"` en `<ul>`
- `focus-visible` outline en cada botón
- SVGs con `aria-hidden="true"`

### Responsive
- **Mobile**: sidebar se oculta (`hidden md:flex`), bottom nav visible
- **Desktop (md+)**: sidebar y bottom nav coexisten
- `pb-20` en `<main>` mobile para no tapar contenido

### TypeScript
- `npx tsc --noEmit` sin errores

https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCYTCtWJ27t6TJPVXhuHgD)_