### PR TITLE
fix(index): corregir ruta /src/main.js absoluta → relativa (pantalla blanca)

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   <script>(function(){if(window.__CA_UNIFIED_SHELL_LOADER__){return;}window.__CA_UNIFIED_SHELL_LOADER__=true;var s=document.createElement('script');var b=location.pathname.indexOf('/antropologia-corrupcion/')===0?'/antropologia-corrupcion/':'/';s.src=b+'shared-shell.js';s.defer=true;document.head.appendChild(s);}());</script>
 </body>
 </html>


### PR DESCRIPTION
## Qué cambia

- `index.html`: `src="/src/main.js"` → `src="./src/main.js"` (1 carácter, 1 causa)

## Tipo de cambio

- [x] `fix` — corrección de bug

## Diagnóstico

El path `/src/main.js` es absoluto: en GitHub Pages, el repo se sirve en el subpath `/antropologia-corrupcion/`, por lo que el navegador resuelve el script como:

```
https://vientonorte.github.io/src/main.js  →  404
```

El módulo ES falla silenciosamente (no hay error visible), `#root` nunca se hidrata y la página queda en blanco. El fix cambia a ruta relativa `./src/main.js` que resuelve correctamente en cualquier subpath y en desarrollo local.

## Checklist

- [x] `node tests/runner.js` pasa en verde localmente
- [x] No se agregan binarios pesados
- [x] Cambio en `index.html` → revisado contra `docs/QA_RESCATE_CONFIANZA_CHECKLIST.md`

## Gate Rescate de Confianza

- [x] Toca `index.html` → checklist QA revisado
- [x] No cambia arquitectura ni stack; alineado con baseline `586cdb3`

## Notas para el revisor

Causa raíz confirmada mediante inspección de red: el browser hace GET `/src/main.js` (sin el prefijo `/antropologia-corrupcion/`) y recibe 404. Cambio quirúrgico de 1 carácter, sin efectos laterales.