### PR TITLE
fix(privacidad+calidad): Bunny Fonts, estilos inline buscador, cat-I badge

### DIFF
--- a/buscador.html
+++ b/buscador.html
@@ -377,10 +377,35 @@
         }
         
         .cat-badge.cat-I {
-            background: rgba(200, 169, 110, .15);
-            color: var(--etica);
+            background: rgba(200, 95, 74, .12);
+            color: var(--crit);
         }
         
+        .results-toolbar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+
+        #btnExportCSV {
+            display: none;
+            padding: 6px 12px;
+            background: var(--s1);
+            border: 1px solid var(--border);
+            border-radius: var(--r);
+            color: var(--muted);
+            font-size: 12px;
+            font-family: var(--font-mono);
+            cursor: pointer;
+            transition: border-color .2s, color .2s;
+        }
+
+        #btnExportCSV:hover {
+            border-color: rgba(255, 255, 255, .2);
+            color: var(--fg);
+        }
+
         .result-date {
             font-family: var(--font-mono);
             font-size: 11px;
@@ -811,11 +836,9 @@
             <div class="cat-desc" id="catDesc" aria-live="polite">Registros de transparencia, SEIA y otras instituciones públicas con deber de publicación activa.</div>
 
             <!-- Results -->
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+            <div class="results-toolbar">
                 <div class="results-status" id="resultsStatus"></div>
-                <button id="btnExportCSV" style="display:none;padding:6px 12px;background:var(--s1);border:1px solid var(--border);border-radius:var(--r);color:var(--muted);font-size:12px;font-family:var(--font-mono);cursor:pointer;transition:all .2s" onmouseover="this.style.borderColor='rgba(255,255,255,.2)';this.style.color='var(--fg)'" onmouseout="this.style.borderColor='var(--border)';this.style.color='var(--muted)'">
-                    📥 Exportar CSV
-                </button>
+                <button id="btnExportCSV">📥 Exportar CSV</button>
             </div>
             <div id="loadingState" style="display:none;padding:48px 0;text-align:center;color:var(--dim);font-size:13px;font-family:var(--font-mono)">Cargando fuentes para búsqueda avanzada…</div>
             <div id="resultsList"></div>

--- a/zuboff-archivo 5.html
+++ b/zuboff-archivo 5.html
@@ -14,7 +14,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📚</text></svg>">
 
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=DM+Mono:wght@300;400&family=Fraunces:ital,wght@0,300;0,600;1,300&display=swap');
+        @import url('https://fonts.bunny.net/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=DM+Mono:wght@300;400&family=Fraunces:ital,wght@0,300;0,600;1,300&display=swap');
          :root {
             --ro: #C2432A;
             --ro-soft: #f0ded9;

--- a/zuboff-archivo.html
+++ b/zuboff-archivo.html
@@ -14,7 +14,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📚</text></svg>">
 
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=DM+Mono:wght@300;400&family=Fraunces:ital,wght@0,300;0,600;1,300&display=swap');
+        @import url('https://fonts.bunny.net/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=DM+Mono:wght@300;400&family=Fraunces:ital,wght@0,300;0,600;1,300&display=swap');
          :root {
             --ro: #C2432A;
             --ro-soft: #f0ded9;


### PR DESCRIPTION
## Qué cambia

### Privacidad — Google Fonts → Bunny Fonts
- `zuboff-archivo.html` y `zuboff-archivo 5.html` usaban `fonts.googleapis.com`
- Migrado a `fonts.bunny.net` (mismo API, sin filtración de IPs a Google)
- El stack del proyecto requiere Bunny Fonts explícitamente; esto cierra la deuda

### Calidad de código — buscador.html
- **Estilos inline eliminados**: el botón `#btnExportCSV` tenía `style=""` + `onmouseover`/`onmouseout` JS inline; extraído a bloque CSS con `.results-toolbar`, `#btnExportCSV` y `#btnExportCSV:hover`
- **cat-badge.cat-I diferenciado**: `.cat-badge.cat-I` duplicaba exactamente el estilo de `.cat-badge.cat-F` (ambos `--etica` dorado); cat-I ahora usa `--crit` (rojo) que corresponde a la capa analítica de Investigaciones

## Tipo de cambio

- [ ] `feat` — nuevo caso, sección o funcionalidad
- [x] `fix` — corrección de bug o datos incorrectos
- [ ] `docs` — changelog, README, HANDOFF
- [ ] `ci` — tests, workflows, scripts
- [ ] `chore` — gitignore, dependencias, limpieza

## Checklist

- [x] No se agregan binarios pesados
- [x] Cambios visuales verificados (buscador: hover funciona vía CSS, badge cat-I distinguible)
- [x] Sin regresiones en `zuboff-archivo.html` (solo cambia dominio de fuente)

## Notas para el revisor

Los tres archivos modificados son cambios de una sola línea lógica cada uno — fácil de auditar. El commit agrupa los tres porque responden a la misma causa raíz: deuda de calidad detectada en el sprint review.