### PR TITLE
feat(archivo): agrega zuboff-citas.html al índice del archivo público

### DIFF
--- a/data/archivo-index.json
+++ b/data/archivo-index.json
@@ -41,6 +41,15 @@
       "estado": "publicable"
     },
     {
+      "id": "zuboff-citas-archivo",
+      "tipo": "dossier",
+      "seccion": "citas",
+      "titulo": "Citas Zuboff — Capitalismo de vigilancia",
+      "descripcion": "Archivo de citas de Shoshana Zuboff: capitalismo de vigilancia, datos de comportamiento, mercados de futuros conductuales y poder instrumental. Eje teórico central del caso SURA y Banca Digital.",
+      "url": "zuboff-citas.html",
+      "estado": "publicable"
+    },
+    {
       "id": "tesis-lecturas-publicas",
       "tipo": "biblioteca",
       "seccion": "biblioteca",


### PR DESCRIPTION
## Resumen

- Agrega entrada `zuboff-citas-archivo` en `data/archivo-index.json`
- La página aparece ahora como card en la sección "Archivo de citas" de `archivo.html`
- Estado `publicable` — la página mantiene su propio auth gate (passkey modal), sin exposición de contenido

## Verificación

- [ ] Navegar a `/archivo.html` → card "Citas Zuboff — Capitalismo de vigilancia" visible en sección "Archivo de citas"
- [ ] Clic en card → redirige a `zuboff-citas.html` con modal de autenticación

https://claude.ai/code/session_01JS9gcpunfCqZTgk8nrZX43

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS9gcpunfCqZTgk8nrZX43)_