### PR TITLE
fix(meta): corrige og:image en 6 páginas que referenciaban captura SURA eliminada

### DIFF
--- a/buscador.html
+++ b/buscador.html
@@ -10,7 +10,7 @@
     <meta property="og:description" content="Búsqueda avanzada del Contra-Archivo con categorías, filtros y score de fricción para análisis trazable de fuentes oficiales chilenas.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vientonorte.github.io/antropologia-corrupcion/buscador.html">
-    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg">
+    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/t-tulos-de-merced-distribuci-n-territorial-del-r.jpg">
     <meta name="theme-color" content="#0c0c0c">
     <link rel="canonical" href="https://vientonorte.github.io/antropologia-corrupcion/buscador.html">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">

--- a/landing.html
+++ b/landing.html
@@ -10,7 +10,7 @@
     <meta property="og:description" content="Investigación doctoral sobre corrupción en Chile como práctica estructural mediada por mistraducción institucional.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vientonorte.github.io/antropologia-corrupcion/landing.html">
-    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg">
+    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/t-tulos-de-merced-distribuci-n-territorial-del-r.jpg">
     <meta name="theme-color" content="#0c0c0c">
     <link rel="canonical" href="https://vientonorte.github.io/antropologia-corrupcion/landing.html">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">

--- a/login.html
+++ b/login.html
@@ -9,7 +9,7 @@
     <meta property="og:title" content="Acceso Privado — Contra-Archivo">
     <meta property="og:description" content="Puerta de acceso privado al espacio de investigación del Contra-Archivo.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg">
+    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/t-tulos-de-merced-distribuci-n-territorial-del-r.jpg">
     <meta name="theme-color" content="#0c0c0c">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">
     <link rel="manifest" href="manifest.json">

--- a/privado-login.html
+++ b/privado-login.html
@@ -10,7 +10,7 @@
 <meta property="og:title" content="Acceso privado — Contra-Archivo">
 <meta property="og:description" content="Ingreso privado con passkey para investigadoras">
 <meta property="og:type" content="website">
-<meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg">
+<meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/t-tulos-de-merced-distribuci-n-territorial-del-r.jpg">
 <meta name="theme-color" content="#0c0c0c">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">
 <link rel="manifest" href="manifest.json">

--- a/privado.html
+++ b/privado.html
@@ -9,7 +9,7 @@
     <meta property="og:title" content="Espacio Privado — Contra-Archivo">
     <meta property="og:description" content="Área privada para investigadores — Contra-Archivo: Antropología y Corrupción">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg">
+    <meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/t-tulos-de-merced-distribuci-n-territorial-del-r.jpg">
     <meta name="theme-color" content="#0c0c0c">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">
     <link rel="manifest" href="manifest.json">

--- a/tesis.html
+++ b/tesis.html
@@ -9,7 +9,7 @@
 <meta property="og:description" content="Tesis doctoral interactiva, poemarios e investigaciones del Colectivo Viento Norte.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://vientonorte.github.io/antropologia-corrupcion/tesis.html">
-<meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg">
+<meta property="og:image" content="https://vientonorte.github.io/antropologia-corrupcion/img/t-tulos-de-merced-distribuci-n-territorial-del-r.jpg">
 <meta name="theme-color" content="#0c0c0c">
 <link rel="canonical" href="https://vientonorte.github.io/antropologia-corrupcion/tesis.html">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">


### PR DESCRIPTION
## Contexto

Seguimiento de #183. Codex identificó que tras eliminar `an-lisis-ux-ui-mapeo-de-vulnerabilidades-de-expe.jpg`, 6 páginas seguían referenciando esa imagen en su `og:image`, generando 404 en previsualizaciones sociales y dejando la redacción incompleta.

## Cambios

Reemplaza `og:image` en los 6 archivos afectados:
- `privado-login.html`
- `buscador.html`
- `landing.html`
- `login.html`
- `tesis.html`
- `privado.html`

Nueva imagen: `t-tulos-de-merced-distribuci-n-territorial-del-r.jpg` — fuente histórica pública (archivo CONADI), sin PII.

https://claude.ai/code/session_013AHrQAcx5GPLq35T7uwW9w

---
_Generated by [Claude Code](https://claude.ai/code/session_013AHrQAcx5GPLq35T7uwW9w)_