### PR TITLE
fix(deploy): styles/ en raíz + pipeline con validación de assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,11 +48,23 @@ jobs:
         with:
           enablement: true
 
+      - name: Validar assets críticos
+        run: |
+          # Verificar que styles/ y src/ existen antes de empaquetar
+          test -d styles || { echo "❌ styles/ no encontrado en raíz — el sitio quedaría sin CSS"; exit 1; }
+          test -f styles/shared.css || { echo "❌ styles/shared.css faltante"; exit 1; }
+          test -f styles/graph.css || { echo "❌ styles/graph.css faltante"; exit 1; }
+          test -d src || { echo "❌ src/ no encontrado en raíz"; exit 1; }
+          test -f src/frictionEngine.js || { echo "❌ src/frictionEngine.js faltante"; exit 1; }
+          echo "✅ Assets críticos presentes"
+
       - name: Preparar artefacto de sitio estático
         run: |
-          # Excluir terraza/ (código fuente Next.js), Estado del Arte/ y otros
-          # directorios de desarrollo que no deben ser accesibles en producción.
-          rm -rf terraza "Estado del Arte" "Ensayo Traducción de Saberes" docs
+          # Excluir directorios de desarrollo que no deben ser públicos.
+          # web/terraza: código fuente Next.js del admin privado
+          # web/: directorio fuente (los assets canonicales ya están en raíz)
+          # Estado del Arte/, Ensayo Traducción de Saberes/, docs/: material de investigación privado
+          rm -rf web "Estado del Arte" "Ensayo Traducción de Saberes" docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/styles/contra-archivo.css
+++ b/styles/contra-archivo.css
@@ -1,0 +1,3669 @@
+/* ══════════════════════════════════════
+   contra-archivo.css — Estilos específicos de index.html
+   Requiere: shared.css (tokens, reset, base)
+   ══════════════════════════════════════ */
+
+
+/* Override: shared.css usa line-height 1.55, este instrumento usa 1.65 */
+
+body {
+    line-height: 1.65;
+}
+
+.graph-mobile-hint {
+    display: none;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 12px;
+    margin: 0 0 14px;
+    border: 1px solid rgba(74, 127, 165, .2);
+    border-radius: 8px;
+    background: rgba(74, 127, 165, .06);
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.45
+}
+
+.graph-mobile-hint strong {
+    color: var(--text)
+}
+
+.graph-mobile-status {
+    display: none;
+    margin: 0 0 14px;
+    padding: 10px 12px;
+    border: 1px solid rgba(200, 169, 110, .18);
+    border-radius: 8px;
+    background: rgba(200, 169, 110, .06);
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.45
+}
+
+.triage-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 18px
+}
+
+.triage-toolbar-copy {
+    font-size: 12px;
+    color: var(--muted)
+}
+
+.triage-toolbar-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap
+}
+
+.se-stats-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 18px
+}
+
+.se-stats-head-copy {
+    display: grid;
+    gap: 4px
+}
+
+.se-stats-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap
+}
+
+.se-audit-note {
+    font-size: 11px;
+    color: var(--muted);
+    line-height: 1.5
+}
+
+.se-export-btn {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-size: 11px;
+    padding: 7px 12px;
+    cursor: pointer
+}
+
+.se-export-btn:hover {
+    border-color: var(--etica);
+    color: var(--etica)
+}
+
+.se-export-btn:disabled {
+    opacity: .45;
+    cursor: not-allowed
+}
+
+.skip-link {
+    position: absolute;
+    top: -100%;
+    left: 16px;
+    z-index: 9999;
+    padding: 8px 16px;
+    color: var(--bg);
+    font-weight: 600;
+    border-radius: 0 0 var(--r) var(--r);
+    text-decoration: none;
+    transition: top .15s
+}
+
+.skip-link:focus {
+    top: 0
+}
+
+ :focus-visible {
+    outline: 2px solid var(--etica);
+    outline-offset: 2px
+}
+
+button:focus-visible,
+a:focus-visible,
+[tabindex]:focus-visible {
+    outline: 2px solid var(--etica);
+    outline-offset: 2px;
+    border-radius: 3px
+}
+
+
+/* ══════════════════════════════════════ UTILITY */
+
+.mono {
+    font-family: var(--font-mono);
+    font-size: .85em
+}
+
+.muted {
+    color: var(--muted)
+}
+
+.label {
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--muted)
+}
+
+.accent-e {
+    color: var(--etica)
+}
+
+.accent-i {
+    color: var(--inst)
+}
+
+.accent-m {
+    color: var(--mat)
+}
+
+.accent-c {
+    color: var(--crit)
+}
+
+
+/* ══════════════════════════════════════ NAV */
+
+.top-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 32px;
+    height: 52px;
+    background: rgba(12, 12, 12, .88);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border)
+}
+
+.nav-brand {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--etica);
+    letter-spacing: .06em
+}
+
+.nav-links {
+    display: flex;
+    gap: 28px
+}
+
+.nav-links a {
+    font-size: 12px;
+    color: var(--muted);
+    text-decoration: none;
+    letter-spacing: .04em;
+    transition: color .15s
+}
+
+.nav-links a:hover {
+    color: var(--text)
+}
+
+.nav-cta {
+    font-size: 11px;
+    padding: 6px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    text-decoration: none;
+    transition: all .15s;
+    letter-spacing: .04em
+}
+
+.nav-cta:hover {
+    background: var(--s2);
+    border-color: var(--etica);
+    color: var(--etica)
+}
+
+
+/* ══════════════════════════════════════ HERO */
+
+#hero {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 120px 40px 80px;
+    max-width: 960px;
+    margin: 0 auto
+}
+
+.hero-label {
+    font-size: 11px;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 28px
+}
+
+.hero-h1 {
+    font-size: clamp(32px, 5vw, 58px);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -.025em;
+    color: var(--text);
+    margin-bottom: 28px
+}
+
+.hero-h1 em {
+    font-style: normal;
+    color: var(--etica)
+}
+
+.hero-thesis {
+    font-size: 18px;
+    color: var(--muted);
+    line-height: 1.6;
+    max-width: 640px;
+    margin-bottom: 48px;
+    border-left: 2px solid var(--etica);
+    padding-left: 20px
+}
+
+.hero-thesis strong {
+    color: var(--text)
+}
+
+
+/* Tensión-metro hero */
+
+.hero-meter {
+    margin-bottom: 56px
+}
+
+.hero-meter-label {
+    font-size: 11px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 12px
+}
+
+.meter-cases {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px
+}
+
+.meter-case {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 14px 16px;
+    cursor: pointer;
+    transition: border-color .2s
+}
+
+.meter-case:hover {
+    border-color: var(--etica)
+}
+
+.meter-case:active {
+    transform: scale(.96);
+    border-color: var(--etica);
+    background: rgba(200, 169, 110, .06)
+}
+
+.mc-name {
+    font-size: 11px;
+    color: var(--muted);
+    margin-bottom: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+.mc-bar-wrap {
+    height: 4px;
+    background: rgba(255, 255, 255, .06);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 6px
+}
+
+.mc-bar {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 1.2s cubic-bezier(.4, 0, .2, 1)
+}
+
+.mc-val {
+    font-family: var(--font-mono);
+    font-size: 16px;
+    font-weight: 700
+}
+
+.mc-tipo {
+    font-size: 10px;
+    color: var(--dim);
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    margin-top: 2px
+}
+
+
+/* ── FRICTION SCORE TOOLTIP ── */
+
+.friction-tip {
+    position: relative;
+    cursor: help
+}
+
+.friction-tip::after {
+    content: attr(data-tip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 8px 12px;
+    background: rgba(12, 12, 12, .96);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.5;
+    white-space: normal;
+    width: max-content;
+    max-width: 260px;
+    text-align: center;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity .2s ease;
+    z-index: 50
+}
+
+.friction-tip:hover::after,
+.friction-tip:focus::after,
+.friction-tip:focus-within::after {
+    opacity: 1
+}
+
+@media (max-width: 600px) {
+    .friction-tip::after {
+        left: 0;
+        transform: none;
+        max-width: 200px
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .friction-tip::after {
+        transition: none
+    }
+}
+
+.hero-ctas {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap
+}
+
+.btn-primary {
+    padding: 12px 24px;
+    background: var(--etica);
+    color: #111;
+    font-weight: 600;
+    border-radius: var(--r);
+    text-decoration: none;
+    font-size: 14px;
+    transition: opacity .15s;
+    border: none;
+    cursor: pointer
+}
+
+.btn-primary:hover {
+    opacity: .88
+}
+
+.btn-ghost {
+    padding: 11px 24px;
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: var(--r);
+    text-decoration: none;
+    font-size: 14px;
+    transition: all .15s
+}
+
+.btn-ghost:hover {
+    border-color: var(--etica);
+    color: var(--etica)
+}
+
+
+/* ══════════════════════════════════════ SECTIONS */
+
+section {
+    padding: 80px 40px;
+    max-width: 960px;
+    margin: 0 auto;
+    scroll-margin-top: 60px /* nav height 52px + 8px breathing room */
+}
+
+.section-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 40px
+}
+
+.eyebrow-num {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--dim)
+}
+
+.eyebrow-line {
+    flex: 1;
+    height: 1px;
+    background: var(--border)
+}
+
+.eyebrow-text {
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--muted)
+}
+
+h2 {
+    font-size: clamp(24px, 3vw, 36px);
+    font-weight: 700;
+    letter-spacing: -.02em;
+    line-height: 1.2;
+    margin-bottom: 16px
+}
+
+.section-lead {
+    font-size: 17px;
+    color: var(--muted);
+    line-height: 1.7;
+    max-width: 680px;
+    margin-bottom: 40px
+}
+
+.section-lead strong {
+    color: var(--text)
+}
+
+
+/* ══════════════════════════════════════ INSTRUMENTO */
+
+#instrumento {
+    border-top: 1px solid var(--border)
+}
+
+.instrument-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 48px;
+    align-items: start
+}
+
+
+/* Las 3 capas */
+
+.capas-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 3px
+}
+
+.capa-card {
+    border-radius: var(--r);
+    padding: 20px 22px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: all .2s;
+    position: relative;
+    overflow: hidden
+}
+
+.capa-card::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px
+}
+
+.capa-e {
+    background: rgba(200, 169, 110, .07);
+    border-color: rgba(200, 169, 110, .2)
+}
+
+.capa-e::before {
+    background: var(--etica)
+}
+
+.capa-e:hover {
+    background: rgba(200, 169, 110, .12);
+    border-color: rgba(200, 169, 110, .35)
+}
+
+.capa-i {
+    background: rgba(74, 127, 165, .07);
+    border-color: rgba(74, 127, 165, .2)
+}
+
+.capa-i::before {
+    background: var(--inst)
+}
+
+.capa-i:hover {
+    background: rgba(74, 127, 165, .12);
+    border-color: rgba(74, 127, 165, .35)
+}
+
+.capa-m {
+    background: rgba(122, 158, 110, .07);
+    border-color: rgba(122, 158, 110, .2)
+}
+
+.capa-m::before {
+    background: var(--mat)
+}
+
+.capa-m:hover {
+    background: rgba(122, 158, 110, .12);
+    border-color: rgba(122, 158, 110, .35)
+}
+
+.capa-sym {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    margin-bottom: 4px
+}
+
+.capa-title {
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 6px
+}
+
+.capa-desc {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.5
+}
+
+
+/* Fricción entre capas */
+
+.friction-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    position: relative
+}
+
+.fi-arrow {
+    width: 1px;
+    height: 28px;
+    background: linear-gradient(to bottom, var(--etica), var(--inst));
+    margin: 0 auto;
+    position: relative
+}
+
+.fi-label {
+    position: absolute;
+    right: 100%;
+    margin-right: 8px;
+    font-size: 10px;
+    color: var(--dim);
+    letter-spacing: .08em;
+    white-space: nowrap
+}
+
+
+/* Diagrama metodológico */
+
+.method-diagram {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 0
+}
+
+.md-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--border)
+}
+
+.md-step:last-child {
+    border-bottom: none
+}
+
+.md-num {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--dim);
+    min-width: 24px;
+    margin-top: 2px
+}
+
+.md-content {}
+
+.md-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 3px
+}
+
+.md-text {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.5
+}
+
+
+/* ══════════════════════════════════════ CAMPOS */
+
+#campos {
+    border-top: 1px solid var(--border)
+}
+
+.campos-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px
+}
+
+.campo-card {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 24px;
+    cursor: pointer;
+    transition: all .2s;
+    position: relative;
+    overflow: hidden
+}
+
+.campo-card::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px
+}
+
+.campo-card:nth-child(1)::after {
+    background: linear-gradient(90deg, var(--etica), transparent)
+}
+
+.campo-card:nth-child(2)::after {
+    background: linear-gradient(90deg, var(--mat), transparent)
+}
+
+.campo-card:nth-child(3)::after {
+    background: linear-gradient(90deg, var(--inst), transparent)
+}
+
+.campo-card:nth-child(4)::after {
+    background: linear-gradient(90deg, var(--crit), transparent)
+}
+
+.campo-card:hover {
+    border-color: rgba(255, 255, 255, .15);
+    transform: translateY(-2px)
+}
+
+.cc-tag {
+    font-size: 10px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 10px
+}
+
+.cc-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    line-height: 1.3
+}
+
+.cc-desc {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.6;
+    margin-bottom: 16px
+}
+
+.cc-actors {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-bottom: 14px
+}
+
+.cc-actor {
+    font-size: 10px;
+    padding: 2px 8px;
+    background: rgba(255, 255, 255, .04);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--dim)
+}
+
+.cc-friction {
+    display: flex;
+    align-items: center;
+    gap: 8px
+}
+
+.ccf-label {
+    font-size: 10px;
+    color: var(--dim);
+    letter-spacing: .05em;
+    text-transform: uppercase
+}
+
+.ccf-bar {
+    flex: 1;
+    height: 3px;
+    background: rgba(255, 255, 255, .06);
+    border-radius: 2px;
+    overflow: hidden
+}
+
+.ccf-fill {
+    height: 100%;
+    border-radius: 2px
+}
+
+.ccf-val {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700
+}
+
+
+/* ══════════════════════════════════════ TENSIONES */
+
+#tensiones {
+    border-top: 1px solid var(--border)
+}
+
+.tension-selector {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 32px;
+    flex-wrap: wrap
+}
+
+.ts-btn {
+    font-size: 12px;
+    padding: 7px 16px;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    transition: all .15s;
+    font-family: inherit
+}
+
+.ts-btn.active {
+    border-color: var(--etica);
+    color: var(--etica);
+    background: rgba(200, 169, 110, .08)
+}
+
+.tension-viewer {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 2px;
+    min-height: 320px
+}
+
+.tv-capa {
+    border-radius: var(--r);
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px
+}
+
+.tv-e {
+    background: rgba(200, 169, 110, .07);
+    border: 1px solid rgba(200, 169, 110, .2)
+}
+
+.tv-i {
+    background: rgba(74, 127, 165, .07);
+    border: 1px solid rgba(74, 127, 165, .2)
+}
+
+.tv-m {
+    background: rgba(122, 158, 110, .07);
+    border: 1px solid rgba(122, 158, 110, .2)
+}
+
+.tvc-sym {
+    font-size: 10px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted)
+}
+
+.tvc-title {
+    font-size: 14px;
+    font-weight: 600
+}
+
+.tvc-body {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.6
+}
+
+.tvc-kws {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: auto
+}
+
+.kw {
+    font-size: 10px;
+    padding: 2px 7px;
+    border-radius: 3px;
+    font-family: var(--font-mono)
+}
+
+.kw-e {
+    background: rgba(200, 169, 110, .12);
+    color: var(--etica)
+}
+
+.kw-i {
+    background: rgba(74, 127, 165, .12);
+    color: var(--inst)
+}
+
+.kw-m {
+    background: rgba(122, 158, 110, .12);
+    color: var(--mat)
+}
+
+.tension-meta {
+    margin-top: 20px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 20px
+}
+
+.tm-item {}
+
+.tm-label {
+    font-size: 10px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--dim);
+    margin-bottom: 4px
+}
+
+.tm-val {
+    font-size: 14px;
+    font-weight: 600
+}
+
+.tm-sub {
+    font-size: 12px;
+    color: var(--muted);
+    margin-top: 4px;
+    line-height: 1.4;
+    font-style: italic
+}
+
+
+/* Intensidad visual */
+
+.intensity-bar {
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, .05);
+    margin-top: 8px
+}
+
+.ib-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: linear-gradient(90deg, var(--mat), var(--etica), var(--crit))
+}
+
+
+/* ══════════════════════════════════════ GRAFO EMBED */
+
+#grafo {
+    border-top: 1px solid var(--border)
+}
+
+.graph-wrap {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    overflow: hidden;
+    position: relative;
+    height: 460px
+}
+
+/* ── Graph node inline panel ── */
+#graph-node-panel {
+    display: none;
+    margin-top: 16px;
+    animation: gnp-in .22s ease
+}
+#graph-node-panel.visible {
+    display: block
+}
+@keyframes gnp-in {
+    from { opacity: 0; transform: translateY(8px) }
+    to   { opacity: 1; transform: translateY(0) }
+}
+.gnp-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px
+}
+.gnp-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text)
+}
+.gnp-close {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: color .15s, border-color .15s
+}
+.gnp-close:hover {
+    color: var(--text);
+    border-color: var(--text)
+}
+.gnp-layers {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 2px
+}
+.gnp-meta {
+    margin-top: 8px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 16px 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 16px
+}
+@media (max-width: 700px) {
+    .gnp-layers { grid-template-columns: 1fr }
+    .gnp-meta   { grid-template-columns: 1fr }
+}
+
+#ca-graph-canvas,
+#ca-graph-canvas-embed {
+    position: relative;
+    width: 100%;
+    height: 100%
+}
+
+.friction-field-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0
+}
+
+.friction-graph-svg {
+    position: relative;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab
+}
+
+.friction-graph-svg:active {
+    cursor: grabbing
+}
+
+.ca-link {
+    stroke: var(--muted);
+    stroke-opacity: 0.5
+}
+
+.ca-link--active {
+    stroke: var(--etica);
+    stroke-opacity: 0.9
+}
+
+.ca-link--dimmed {
+    stroke-opacity: 0.12
+}
+
+.ca-node {
+    cursor: pointer;
+    transition: opacity .2s
+}
+
+.ca-node--hovered {
+    filter: brightness(1.15)
+}
+
+.ca-node--selected .ca-friction-center {
+    stroke: var(--etica);
+    stroke-width: 2
+}
+
+.ca-node--dimmed {
+    opacity: 0.2;
+    pointer-events: none
+}
+
+.ca-label text {
+    fill: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    pointer-events: none;
+    user-select: none
+}
+
+.graph-overlay-legend {
+    position: absolute;
+    bottom: 16px;
+    right: 16px;
+    background: rgba(12, 12, 12, .88);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px
+}
+
+.gl-item {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 11px;
+    color: var(--muted)
+}
+
+.gl-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0
+}
+
+.graph-controls {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px
+}
+
+.gc-btn {
+    font-size: 11px;
+    padding: 5px 13px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font-family: inherit;
+    transition: all .15s
+}
+
+.gc-btn.active {
+    border-color: var(--etica);
+    color: var(--etica);
+    background: rgba(200, 169, 110, .08)
+}
+
+.graph-onboarding {
+    margin: 0 0 14px;
+    border: 1px solid rgba(200, 169, 110, .28);
+    background: linear-gradient(90deg, rgba(200, 169, 110, .08) 0%, rgba(74, 127, 165, .08) 100%);
+    border-radius: 8px;
+    padding: 12px 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px
+}
+
+.graph-onboarding strong {
+    color: var(--text)
+}
+
+.graph-onboarding-text {
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.45
+}
+
+.graph-onboarding-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: nowrap
+}
+
+.graph-onboarding-btn {
+    border: 1px solid var(--border);
+    background: rgba(12, 12, 12, .55);
+    color: var(--muted);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 11px;
+    cursor: pointer
+}
+
+.graph-onboarding-btn:hover {
+    color: var(--text);
+    border-color: var(--etica)
+}
+
+
+/* ══════════════════════════════════════ PROTOCOLO */
+
+#protocolo {
+    border-top: 1px solid var(--border)
+}
+
+.protocolo-intro {
+    font-size: 15px;
+    color: var(--muted);
+    line-height: 1.7;
+    max-width: 680px;
+    margin-bottom: 40px
+}
+
+.protocolo-intro strong {
+    color: var(--text)
+}
+
+.umbral-visual {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 24px;
+    margin-bottom: 32px
+}
+
+.uv-title {
+    font-size: 12px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 16px
+}
+
+.uv-scale {
+    position: relative;
+    height: 40px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: linear-gradient(90deg, rgba(122, 158, 110, .3) 0%, rgba(200, 169, 110, .3) 55%, rgba(200, 95, 74, .5) 75%, rgba(200, 95, 74, .9) 100%)
+}
+
+.uv-markers {
+    display: flex;
+    position: relative;
+    margin-top: 8px;
+    font-size: 10px;
+    color: var(--dim)
+}
+
+.uv-mk {
+    position: absolute;
+    transform: translateX(-50%);
+    text-align: center
+}
+
+.uv-mk-line {
+    width: 1px;
+    height: 10px;
+    background: var(--dim);
+    margin: 0 auto 3px
+}
+
+.uv-cases {
+    display: flex;
+    gap: 6px;
+    margin-top: 16px;
+    flex-wrap: wrap
+}
+
+.uvc {
+    font-size: 11px;
+    padding: 3px 10px;
+    border-radius: 3px;
+    border: 1px solid
+}
+
+.uvc-ok {
+    border-color: var(--mat);
+    color: var(--mat);
+    background: rgba(122, 158, 110, .08)
+}
+
+.uvc-warn {
+    border-color: var(--etica);
+    color: var(--etica);
+    background: rgba(200, 169, 110, .08)
+}
+
+.uvc-crit {
+    border-color: var(--crit);
+    color: var(--crit);
+    background: rgba(200, 95, 74, .08)
+}
+
+#triage {
+    border-top: 1px solid var(--border)
+}
+
+.triage-intro {
+    display: grid;
+    gap: 10px;
+    margin-bottom: 28px
+}
+
+.triage-kpis {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 24px
+}
+
+.triage-kpi {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 18px
+}
+
+.triage-kpi-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--dim);
+    margin-bottom: 6px
+}
+
+.triage-kpi-value {
+    font-family: var(--font-mono);
+    font-size: 26px;
+    color: var(--text)
+}
+
+.triage-kpi-sub {
+    font-size: 11px;
+    color: var(--muted);
+    margin-top: 6px
+}
+
+.triage-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin-bottom: 24px
+}
+
+.triage-card {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 20px;
+    display: grid;
+    gap: 14px
+}
+
+.triage-card-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px
+}
+
+.triage-card-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text)
+}
+
+.triage-card-meta {
+    font-size: 11px;
+    color: var(--muted);
+    margin-top: 6px
+}
+
+.triage-card-chip {
+    font-size: 10px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    border: 1px solid rgba(200, 169, 110, .24);
+    background: rgba(200, 169, 110, .08);
+    color: var(--etica);
+    white-space: nowrap
+}
+
+.triage-metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px
+}
+
+.triage-metric {
+    border: 1px solid rgba(255, 255, 255, .05);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, .02);
+    padding: 10px
+}
+
+.triage-metric-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--dim);
+    margin-bottom: 5px
+}
+
+.triage-metric-value {
+    font-family: var(--font-mono);
+    font-size: 16px;
+    color: var(--text)
+}
+
+.triage-source-bars {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 8px;
+    align-items: end
+}
+
+.triage-source-bar {
+    display: grid;
+    justify-items: center;
+    gap: 6px
+}
+
+.triage-source-track {
+    width: 100%;
+    min-height: 58px;
+    background: rgba(255, 255, 255, .04);
+    border-radius: 999px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, .04)
+}
+
+.triage-source-fill {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 999px;
+    min-height: 10%;
+    opacity: .95
+}
+
+.triage-source-icon {
+    font-size: 13px
+}
+
+.triage-source-count {
+    font-size: 10px;
+    color: var(--dim);
+    font-family: var(--font-mono)
+}
+
+.triage-gaps,
+.triage-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px
+}
+
+.triage-gap-pill {
+    font-size: 10px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    color: var(--crit);
+    border: 1px solid rgba(200, 95, 74, .24);
+    background: rgba(200, 95, 74, .08)
+}
+
+.triage-open-btn {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-size: 11px;
+    padding: 7px 12px;
+    cursor: pointer
+}
+
+.triage-open-btn:hover {
+    border-color: var(--etica);
+    color: var(--etica)
+}
+
+.triage-table-wrap {
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    overflow: auto;
+    background: var(--s1)
+}
+
+.triage-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 760px
+}
+
+.triage-table th,
+.triage-table td {
+    padding: 12px 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, .05);
+    text-align: left;
+    font-size: 12px
+}
+
+.triage-table th {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--dim);
+    background: rgba(255, 255, 255, .02)
+}
+
+.triage-table td {
+    color: var(--muted)
+}
+
+.triage-table strong {
+    color: var(--text)
+}
+
+/* Brecha 2: CTA Triage → Protocolo */
+.triage-protocolo-cta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 24px;
+    padding: 14px 20px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--mat, #7a9e6e);
+    border-radius: var(--r, 8px);
+    flex-wrap: wrap
+}
+
+.triage-protocolo-cta-text {
+    font-size: .84rem;
+    color: var(--muted)
+}
+
+.triage-protocolo-link {
+    font-size: .84rem;
+    color: var(--mat, #7a9e6e);
+    font-weight: 700;
+    text-decoration: none;
+    white-space: nowrap
+}
+
+.triage-protocolo-link:hover {
+    text-decoration: underline
+}
+
+/* Brecha 4: botón Seguir en cards de búsqueda */
+.se-card-seguir {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 8px;
+    padding: 4px 10px;
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    color: var(--muted);
+    font-size: 11px;
+    cursor: pointer;
+    transition: border-color .15s, color .15s
+}
+
+.se-card-seguir:hover {
+    border-color: var(--etica);
+    color: var(--etica)
+}
+
+.se-card-seguir.is-seguido {
+    border-color: var(--etica);
+    color: var(--etica);
+    background: rgba(200,169,110,.08)
+}
+
+.protocolo-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-bottom: 32px
+}
+
+.pc {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 22px;
+    position: relative;
+    overflow: hidden
+}
+
+.pc::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px
+}
+
+.pc:nth-child(1)::before {
+    background: var(--inst)
+}
+
+.pc:nth-child(2)::before {
+    background: var(--etica)
+}
+
+.pc:nth-child(3)::before {
+    background: var(--mat)
+}
+
+.pc:nth-child(4)::before {
+    background: var(--crit)
+}
+
+.pc-num {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--dim);
+    margin-bottom: 8px
+}
+
+.pc-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 8px
+}
+
+.pc-body {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.6;
+    margin-bottom: 12px
+}
+
+.pc-cond {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--dim);
+    padding: 8px 10px;
+    background: rgba(255, 255, 255, .03);
+    border-radius: 4px;
+    border-left: 2px solid var(--border)
+}
+
+.pc-cond strong {
+    color: var(--text)
+}
+
+.protocolo-output {
+    border: 1px solid rgba(200, 169, 110, .3);
+    border-radius: var(--r);
+    padding: 28px;
+    background: rgba(200, 169, 110, .04);
+    display: flex;
+    flex-direction: column;
+    gap: 12px
+}
+
+.po-label {
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--etica)
+}
+
+.po-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text)
+}
+
+.po-body {
+    font-size: 14px;
+    color: var(--muted);
+    line-height: 1.7;
+    max-width: 640px
+}
+
+.po-body strong {
+    color: var(--text)
+}
+
+
+/* ── Pipeline de exportación dual ── */
+
+.protocolo-pipeline {
+    margin-top: 32px;
+    border: 1px solid rgba(74, 127, 165, .25);
+    border-radius: var(--r);
+    padding: 28px;
+    background: rgba(74, 127, 165, .04)
+}
+
+.pp-header {
+    margin-bottom: 24px
+}
+
+.pp-eyebrow {
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--institucional);
+    margin-bottom: 6px
+}
+
+.pp-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text);
+    margin: 0 0 8px
+}
+
+.pp-desc {
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.6;
+    max-width: 640px;
+    margin: 0
+}
+
+.pp-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    margin-bottom: 20px
+}
+
+.pp-card {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px
+}
+
+.pp-card-icon {
+    font-size: 24px;
+    line-height: 1
+}
+
+.pp-card-label {
+    font-size: 10px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted)
+}
+
+.pp-card-title {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--text)
+}
+
+.pp-card-body {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.6;
+    flex: 1
+}
+
+.pp-select {
+    background: var(--s2);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    font-size: 12px;
+    padding: 6px 8px;
+    width: 100%;
+    cursor: pointer
+}
+
+.pp-select:focus {
+    outline: 2px solid var(--institucional);
+    outline-offset: 1px
+}
+
+.pp-btn {
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    padding: 7px 14px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: opacity .15s
+}
+
+.pp-btn:hover:not(:disabled) { opacity: .85 }
+.pp-btn:disabled { opacity: .4; cursor: not-allowed }
+
+.pp-btn-primary {
+    background: var(--institucional);
+    color: #fff
+}
+
+.pp-btn-secondary {
+    background: var(--s2);
+    color: var(--text);
+    border: 1px solid var(--border)
+}
+
+.pp-export-btns {
+    display: flex;
+    gap: 8px
+}
+
+.pp-zuboff-nota {
+    font-size: 11px;
+    color: var(--muted);
+    border-top: 1px solid var(--border);
+    padding-top: 14px;
+    line-height: 1.6
+}
+
+.pp-zuboff-nota strong { color: var(--etica) }
+
+@media (max-width: 768px) {
+    .pp-grid { grid-template-columns: 1fr }
+}
+
+
+
+
+#archivo {
+    border-top: 1px solid var(--border)
+}
+
+.archivo-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px
+}
+
+.arc-dim {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 18px;
+    transition: border-color .2s
+}
+
+.arc-dim:hover {
+    border-color: rgba(255, 255, 255, .15)
+}
+
+.arc-num {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--dim);
+    margin-bottom: 8px
+}
+
+.arc-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 6px
+}
+
+.arc-count {
+    font-size: 11px;
+    color: var(--muted);
+    margin-bottom: 10px
+}
+
+.arc-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px
+}
+
+.arc-tag {
+    font-size: 10px;
+    padding: 2px 6px;
+    background: rgba(255, 255, 255, .04);
+    border-radius: 3px;
+    color: var(--dim)
+}
+
+.arc-link {
+    display: inline-block;
+    margin-top: 12px;
+    font-size: 11px;
+    color: var(--muted);
+    text-decoration: none;
+    letter-spacing: .04em;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1px;
+    transition: all .15s
+}
+
+.arc-link:hover {
+    color: var(--etica);
+    border-color: var(--etica)
+}
+
+
+/* ══════════════════════════════════════ FOOTER */
+
+footer {
+    border-top: 1px solid var(--border);
+    padding: 40px;
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 20px
+}
+
+.footer-left {}
+
+.footer-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 4px
+}
+
+.footer-sub {
+    font-size: 12px;
+    color: var(--muted)
+}
+
+.footer-right {
+    font-size: 11px;
+    color: var(--dim);
+    text-align: right;
+    line-height: 1.8
+}
+
+
+/* ══════════════════════════════════════ DIVIDER */
+
+.full-divider {
+    width: 100%;
+    height: 1px;
+    background: var(--border)
+}
+
+
+/* ══════════════════════════════════════ SCROLLBAR */
+
+ ::-webkit-scrollbar {
+    width: 5px
+}
+
+ ::-webkit-scrollbar-track {
+    background: transparent
+}
+
+ ::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, .1);
+    border-radius: 3px
+}
+
+
+/* ══════════════════════════════════════ LOADING SKELETON */
+
+.viz-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 5;
+    background: var(--s1);
+    transition: opacity .4s ease;
+    pointer-events: none
+}
+
+.viz-loading.loaded {
+    opacity: 0
+}
+
+.viz-loading.error .viz-spinner {
+    border-top-color: var(--crit);
+    animation: none;
+    border-color: rgba(200, 95, 74, .2);
+    border-top-color: var(--crit)
+}
+
+.viz-loading.error .skeleton-graph {
+    display: none
+}
+
+.viz-loading.error .viz-loading-text {
+    color: var(--crit)
+}
+
+.viz-loading-inner {
+    text-align: center;
+    color: var(--dim)
+}
+
+.viz-spinner {
+    width: 28px;
+    height: 28px;
+    border: 2px solid var(--border);
+    border-top-color: var(--etica);
+    border-radius: 50%;
+    animation: viz-spin .8s linear infinite;
+    margin: 0 auto 10px
+}
+
+@keyframes viz-spin {
+    to {
+        transform: rotate(360deg)
+    }
+}
+
+.viz-loading-text {
+    font-size: 11px;
+    letter-spacing: .06em;
+    font-family: var(--font-mono)
+}
+
+
+/* ── SKELETON GRAPH LOADER ── */
+
+.skeleton-graph {
+    width: 180px;
+    height: 120px;
+    margin: 0 auto 12px;
+    display: block
+}
+
+.skeleton-link {
+    stroke: var(--border);
+    stroke-width: 1.5;
+    stroke-dasharray: 6 4;
+    animation: skeleton-pulse 1.6s ease-in-out infinite
+}
+
+.skeleton-node {
+    fill: rgba(255, 255, 255, .06);
+    stroke-width: 2;
+    animation: skeleton-pulse 1.6s ease-in-out infinite
+}
+
+.skeleton-node--etica {
+    stroke: var(--etica)
+}
+
+.skeleton-node--inst {
+    stroke: var(--inst)
+}
+
+.skeleton-node--mat {
+    stroke: var(--mat)
+}
+
+@keyframes skeleton-pulse {
+    0%,
+    100% {
+        opacity: .3
+    }
+    50% {
+        opacity: .8
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .skeleton-link,
+    .skeleton-node {
+        animation: none;
+        opacity: .5
+    }
+}
+
+
+/* ══════════════════════════════════════ SCROLL-TOP FAB */
+
+.scroll-top-fab {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 190;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(12, 12, 12, .88);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 18px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .25s, transform .15s
+}
+
+.scroll-top-fab.visible {
+    opacity: 1;
+    pointer-events: auto
+}
+
+.scroll-top-fab:hover {
+    border-color: var(--etica);
+    color: var(--etica);
+    transform: translateY(-2px)
+}
+
+
+/* ══════════════════════════════════════ QUICK-ACCESS BAR */
+
+.quick-access {
+    position: fixed;
+    right: 24px;
+    bottom: 76px;
+    z-index: 189;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .3s ease, transform .3s ease;
+    transform: translateY(8px)
+}
+
+.quick-access.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0)
+}
+
+.qa-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: rgba(12, 12, 12, .92);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    color: var(--muted);
+    text-decoration: none;
+    font-size: 12px;
+    font-family: var(--font-mono);
+    letter-spacing: .04em;
+    white-space: nowrap;
+    transition: border-color .2s, color .2s, transform .15s
+}
+
+.qa-btn:hover,
+.qa-btn:focus-visible {
+    border-color: var(--etica);
+    color: var(--etica);
+    transform: translateX(-4px)
+}
+
+.qa-btn:focus-visible {
+    outline: 2px solid var(--etica);
+    outline-offset: 2px
+}
+
+.qa-icon {
+    font-size: 14px;
+    line-height: 1
+}
+
+@media(max-width:768px) {
+    .quick-access {
+        display: none !important
+    }
+}
+
+
+/* ══════════════════════════════════════ RESPONSIVE */
+
+@media(max-width:768px) {
+    .top-nav .nav-links {
+        display: none
+    }
+    section {
+        padding: 48px 20px
+    }
+    #hero {
+        padding: 100px 20px 48px;
+        min-height: auto
+    }
+    .hero-h1 {
+        font-size: clamp(26px, 7vw, 36px)
+    }
+    .hero-thesis {
+        font-size: 16px;
+        padding-left: 14px
+    }
+    .meter-cases {
+        grid-template-columns: 1fr 1fr
+    }
+    .instrument-grid {
+        grid-template-columns: 1fr
+    }
+    .campos-grid {
+        grid-template-columns: 1fr
+    }
+    .tension-viewer {
+        grid-template-columns: 1fr
+    }
+    .graph-controls {
+        flex-wrap: wrap;
+        position: sticky;
+        top: 10px;
+        z-index: 12;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        background: rgba(12, 12, 12, .92);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 10px
+    }
+    .graph-onboarding {
+        flex-direction: column;
+        align-items: flex-start
+    }
+    .graph-onboarding-actions {
+        width: 100%
+    }
+    .gc-btn {
+        font-size: 11px;
+        padding: 8px 10px;
+        min-height: 40px
+    }
+    .graph-overlay-legend {
+        top: 8px;
+        left: 8px;
+        right: 8px;
+        bottom: auto;
+        padding: 8px 10px;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between
+    }
+    .graph-wrap {
+        height: min(68vh, 520px)
+    }
+    .graph-mobile-hint,
+    .graph-mobile-status {
+        display: block
+    }
+    .triage-toolbar,
+    .se-stats-head {
+        align-items: flex-start
+    }
+    .sf-metrics {
+        gap: 12px
+    }
+    .sf-metric {
+        min-width: 70px
+    }
+    .sf-value {
+        font-size: 15px
+    }
+    .sf-legend {
+        font-size: .65rem !important;
+        gap: 10px !important
+    }
+    .triage-kpis,
+    .triage-grid,
+    .triage-metrics {
+        grid-template-columns: 1fr
+    }
+    .triage-source-bars {
+        gap: 6px
+    }
+    .protocolo-grid {
+        grid-template-columns: 1fr
+    }
+    .archivo-grid {
+        grid-template-columns: 1fr 1fr
+    }
+    h2 {
+        font-size: clamp(20px, 5vw, 28px)
+    }
+    .section-lead {
+        font-size: 15px
+    }
+    .hero-ctas {
+        flex-direction: column;
+        gap: 10px
+    }
+    .hero-ctas a {
+        text-align: center
+    }
+    .scroll-top-fab {
+        bottom: 80px;
+        right: 16px;
+        width: 36px;
+        height: 36px;
+        font-size: 15px
+    }
+    footer {
+        flex-direction: column;
+        gap: 20px;
+        padding: 32px 20px
+    }
+}
+
+
+/* ══════════════════════════════════════ GRAPH THESIS PANEL */
+
+.graph-thesis {
+    margin-top: 24px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    overflow: hidden
+}
+
+.graph-thesis-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 16px 20px;
+    background: transparent;
+    border: none;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: .02em;
+    transition: background .15s
+}
+
+.graph-thesis-toggle:hover {
+    background: rgba(255, 255, 255, .02)
+}
+
+.graph-thesis-toggle .gt-arrow {
+    font-size: 11px;
+    color: var(--muted);
+    transition: transform .25s
+}
+
+.graph-thesis.open .gt-arrow {
+    transform: rotate(180deg)
+}
+
+.graph-thesis-body {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height .35s ease
+}
+
+.graph-thesis.open .graph-thesis-body {
+    max-height: 600px
+}
+
+.gt-content {
+    padding: 0 20px 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px
+}
+
+.gt-card {
+    padding: 16px;
+    border-radius: 6px;
+    border: 1px solid var(--border)
+}
+
+.gt-card-icon {
+    font-size: 16px;
+    margin-bottom: 8px;
+    display: block
+}
+
+.gt-card-title {
+    font-size: 12px;
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: var(--text)
+}
+
+.gt-card-body {
+    font-size: 11px;
+    color: var(--muted);
+    line-height: 1.55
+}
+
+.gt-card-body strong {
+    color: var(--text)
+}
+
+.gt-full {
+    grid-column: 1 / -1;
+    border-color: rgba(200, 169, 110, .2);
+    background: rgba(200, 169, 110, .03)
+}
+
+.gt-full .gt-card-title {
+    color: var(--etica)
+}
+
+@media(max-width:768px) {
+    .gt-content {
+        grid-template-columns: 1fr
+    }
+}
+
+
+/* ═══════════════ SOCIAL FIELD — ENTROPÍA SOCIAL ═══════════════ */
+
+.social-field-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    pointer-events: none
+}
+
+#campo-social-wrap {
+    position: relative;
+    height: 500px;
+    overflow: hidden;
+    border-radius: 8px;
+    background: #0a0c0e;
+    border: 1px solid rgba(200, 169, 110, .12)
+}
+
+#campo-social-canvas {
+    position: relative;
+    width: 100%;
+    height: 100%
+}
+
+.sf-metrics {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+    padding: 14px 0 0
+}
+
+.sf-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 90px
+}
+
+.sf-label {
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: rgba(200, 169, 110, .5)
+}
+
+.sf-value {
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 18px;
+    color: rgba(200, 169, 110, .9)
+}
+
+.sf-sub {
+    font-size: 10px;
+    color: rgba(200, 169, 110, .35)
+}
+
+.sf-spark {
+    margin-top: 4px
+}
+
+.sf-status--stable {
+    color: rgba(120, 180, 200, .8)
+}
+
+.sf-status--degraded {
+    color: rgba(200, 169, 110, .9)
+}
+
+.sf-status--critical {
+    color: rgba(200, 100, 60, .9)
+}
+
+.sf-status--collapse {
+    color: rgba(180, 50, 40, .95);
+    animation: sf-pulse 1.2s ease-in-out infinite
+}
+
+@keyframes sf-pulse {
+    0%,
+    100% {
+        opacity: 1
+    }
+    50% {
+        opacity: .5
+    }
+}
+
+.sf-controls {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px
+}
+
+.sf-btn {
+    background: rgba(200, 169, 110, .08);
+    border: 1px solid rgba(200, 169, 110, .18);
+    color: rgba(200, 169, 110, .7);
+    font-size: 11px;
+    padding: 5px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all .2s ease
+}
+
+.sf-btn:hover {
+    background: rgba(200, 169, 110, .15);
+    color: rgba(200, 169, 110, .95)
+}
+
+.sf-metrics--enhanced {
+    gap: 16px;
+    align-items: flex-start
+}
+
+.sf-metric--entropy {
+    flex: 1;
+    min-width: 160px
+}
+
+.sf-phase {
+    display: inline-block;
+    font-size: 8px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: 3px;
+    margin-top: 2px;
+    background: rgba(200, 169, 110, .08);
+    color: rgba(200, 169, 110, .6);
+    border: 1px solid rgba(200, 169, 110, .12)
+}
+
+.sf-bar {
+    width: 100%;
+    height: 4px;
+    background: rgba(200, 169, 110, .08);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-top: 4px
+}
+
+.sf-bar__fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width .6s ease, background .6s ease
+}
+
+
+/* ─── Black-Scholes equation display (campo-social) ─── */
+
+.sf-bs-equation {
+    border: 1px solid rgba(74, 127, 165, .25);
+    border-left: 3px solid rgba(74, 127, 165, .6);
+    background: rgba(74, 127, 165, .04);
+    border-radius: 4px;
+    padding: 20px 24px;
+    margin: 24px 0;
+    font-size: .85rem
+}
+
+.sf-bs-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+    flex-wrap: wrap
+}
+
+.sf-bs-eyebrow {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: .72rem;
+    color: rgba(74, 127, 165, .8);
+    text-transform: uppercase;
+    letter-spacing: .06em
+}
+
+.sf-bs-badge {
+    font-size: .72rem;
+    color: var(--dim);
+    border: 1px solid rgba(255, 255, 255, .1);
+    border-radius: 3px;
+    padding: 1px 7px
+}
+
+.sf-bs-formula {
+    font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+    font-size: 1.3rem;
+    letter-spacing: .04em;
+    margin: 14px 0 18px;
+    line-height: 1.8
+}
+
+.sf-bs-op {
+    color: var(--dim);
+    margin: 0 2px
+}
+
+.sf-bs-fn {
+    color: rgba(200, 169, 110, .75)
+}
+
+.sf-bs-c { color: var(--etica); font-weight: 600 }
+.sf-bs-s { color: rgba(74, 127, 165, .9); font-weight: 600 }
+.sf-bs-k { color: var(--mat); font-weight: 600 }
+
+.sf-bs-reinterp {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 6px 16px;
+    margin-bottom: 14px
+}
+
+.sf-bs-var-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: .8rem
+}
+
+.sf-bs-var {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: .95rem;
+    font-weight: 700;
+    min-width: 18px
+}
+
+.sf-bs-sigma { color: rgba(200, 169, 110, .9) }
+.sf-bs-t     { color: var(--dim) }
+
+.sf-bs-var-label {
+    color: var(--dim);
+    line-height: 1.4
+}
+
+.sf-bs-nota {
+    font-size: .8rem;
+    color: var(--dim);
+    line-height: 1.6;
+    border-top: 1px solid rgba(255, 255, 255, .06);
+    padding-top: 12px;
+    margin: 0
+}
+
+/* ─── Grid de dos ecuaciones ─── */
+
+.sf-equations-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 24px 0
+}
+
+@media(max-width: 900px) {
+    .sf-equations-grid {
+        grid-template-columns: 1fr
+    }
+}
+
+/* Mapa logístico: acento levemente distinto */
+.sf-eq-logistic {
+    border-left-color: rgba(200, 169, 110, .6)
+}
+
+/* Black-Scholes PDE: acento azul */
+.sf-eq-bs {
+    border-left-color: rgba(74, 127, 165, .6)
+}
+
+/* Fracciones PDE: ∂V/∂t */
+.sf-bs-frac {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    vertical-align: middle;
+    line-height: 1.1;
+    font-size: .9em;
+    margin: 0 2px
+}
+
+.sf-bs-frac-num {
+    border-bottom: 1px solid rgba(255, 255, 255, .35);
+    padding: 0 2px 1px
+}
+
+.sf-bs-frac-den {
+    padding: 1px 2px 0
+}
+
+/* PDE formula: más compacta que la solución cerrada */
+.sf-bs-formula--pde {
+    font-size: 1.05rem;
+    margin-bottom: 8px
+}
+
+/* Solución cerrada: debajo de la PDE, con etiqueta */
+.sf-bs-formula--closed {
+    font-size: 1rem;
+    border-top: 1px solid rgba(255, 255, 255, .06);
+    padding-top: 10px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2px
+}
+
+.sf-bs-sub-label {
+    font-size: .7rem;
+    color: var(--dim);
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    margin-right: 8px
+}
+
+.sf-bs-sub {
+    font-size: .7em;
+    vertical-align: sub
+}
+
+/* Badges de régimen del mapa logístico */
+.sf-badge-stable {
+    color: rgba(74, 127, 165, .9);
+    border-color: rgba(74, 127, 165, .3)
+}
+
+.sf-badge-bifurc {
+    color: rgba(200, 169, 110, .9);
+    border-color: rgba(200, 169, 110, .3)
+}
+
+.sf-badge-chaos {
+    color: rgba(180, 60, 50, .9);
+    border-color: rgba(180, 60, 50, .4);
+    animation: sf-pulse 1.2s ease-in-out infinite
+}
+
+/* Métrica de mapa logístico en panel */
+.sf-metric--logistic .sf-label {
+    font-size: .6rem
+}
+
+
+/* ═══════════════ VIZ RESPONSIVE (post-cascade) ═══════════════ */
+
+@media(max-width:768px) {
+    .graph-wrap {
+        height: 320px
+    }
+    #campo-social-wrap {
+        height: 340px
+    }
+    .sf-controls {
+        flex-wrap: wrap;
+        justify-content: center
+    }
+}
+
+@media(min-width:1200px) {
+    .graph-wrap {
+        height: 560px
+    }
+    #campo-social-wrap {
+        height: 580px
+    }
+}
+
+
+/* ═══════════════ BOTTOM NAVIGATION (MOBILE) ═══════════════ */
+
+.bottom-nav {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: rgba(12, 12, 12, .95);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-top: 1px solid rgba(200, 169, 110, .12);
+    padding: 4px 4px calc(4px + env(safe-area-inset-bottom));
+    justify-content: space-around;
+    align-items: center;
+    gap: 0
+}
+
+.bottom-nav a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    font-size: 9px;
+    color: var(--muted);
+    text-decoration: none;
+    padding: 6px 2px 4px;
+    border-radius: 8px;
+    transition: color .15s, background .15s, transform .1s;
+    letter-spacing: .02em;
+    min-width: 0;
+    flex: 1 1 0;
+    min-height: 44px;
+    text-align: center;
+    -webkit-tap-highlight-color: transparent;
+    position: relative;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis
+}
+
+.bottom-nav a:active {
+    transform: scale(.92)
+}
+
+.bottom-nav a .bn-icon {
+    font-size: 18px;
+    line-height: 1
+}
+
+.bottom-nav a.active {
+    color: var(--etica)
+}
+
+.bottom-nav a.active::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--etica)
+}
+
+.bottom-nav a:hover {
+    color: var(--text)
+}
+
+@media(max-width:768px) {
+    .bottom-nav {
+        display: flex
+    }
+    body {
+        padding-bottom: 68px
+    }
+}
+
+
+/* ═══════════════ BUSCADOR DE FRICCIÓN INSTITUCIONAL ═══════════════ */
+
+#buscador {
+    border-top: 1px solid var(--border)
+}
+
+.se-search-bar {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 24px;
+    flex-wrap: wrap
+}
+
+.se-input-wrap {
+    flex: 1;
+    min-width: 240px;
+    position: relative
+}
+
+.se-input-wrap::before {
+    content: '⊘';
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--dim);
+    font-size: 14px;
+    pointer-events: none
+}
+
+#se-search-input {
+    width: 100%;
+    padding: 12px 16px 12px 38px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    color: var(--text);
+    font-size: 14px;
+    font-family: var(--font-sans);
+    transition: border-color .2s
+}
+
+#se-search-input:focus {
+    outline: none;
+    border-color: var(--etica)
+}
+
+#se-search-input::placeholder {
+    color: var(--dim)
+}
+
+.se-filters {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap
+}
+
+.se-select {
+    padding: 10px 14px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    color: var(--muted);
+    font-size: 12px;
+    font-family: var(--font-sans);
+    cursor: pointer;
+    transition: border-color .2s;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    padding-right: 30px
+}
+
+.se-select:focus {
+    outline: none;
+    border-color: var(--etica)
+}
+
+.se-card {
+    transition: border-color .18s, box-shadow .18s, transform .12s
+}
+
+.se-card--selected {
+    border-color: var(--etica) !important;
+    box-shadow: 0 0 0 1px rgba(200, 169, 110, .24), 0 8px 24px rgba(0, 0, 0, .24);
+    transform: translateY(-1px)
+}
+
+#se-facets-panel {
+    margin-bottom: 18px
+}
+
+.se-facets {
+    display: grid;
+    gap: 12px;
+    padding: 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: rgba(255, 255, 255, .02)
+}
+
+.se-facets-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap
+}
+
+.se-facets-title {
+    font-size: 11px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--etica)
+}
+
+.se-facets-subtitle {
+    font-size: 12px;
+    color: var(--muted)
+}
+
+.se-facets-reset {
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted);
+    border-radius: 999px;
+    padding: 6px 10px;
+    font-size: 11px;
+    cursor: pointer
+}
+
+.se-facets-reset:hover {
+    color: var(--text);
+    border-color: var(--etica)
+}
+
+.se-facet-group {
+    display: grid;
+    gap: 8px
+}
+
+.se-facet-label {
+    font-size: 10px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--dim)
+}
+
+.se-facet-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px
+}
+
+.se-facet-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--border);
+    background: rgba(12, 12, 12, .4);
+    color: var(--muted);
+    border-radius: 999px;
+    padding: 6px 10px;
+    font-size: 11px;
+    cursor: pointer
+}
+
+.se-facet-btn:hover {
+    color: var(--text);
+    border-color: rgba(200, 169, 110, .35)
+}
+
+.se-facet-btn.active {
+    border-color: var(--etica);
+    color: var(--etica);
+    background: rgba(200, 169, 110, .08)
+}
+
+.se-facet-count {
+    font-family: var(--font-mono);
+    color: var(--dim)
+}
+
+#se-stats-panel {
+    margin-bottom: 24px
+}
+
+.se-stats {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 20px
+}
+
+.se-stats-summary {
+    display: flex;
+    gap: 32px;
+    margin-bottom: 16px;
+    flex-wrap: wrap
+}
+
+.se-stats-evidence {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px
+}
+
+.se-stat-big {
+    display: flex;
+    flex-direction: column;
+    gap: 2px
+}
+
+.se-stat-num {
+    font-family: var(--font-mono);
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--text)
+}
+
+.se-stat-desc {
+    font-size: 11px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--muted)
+}
+
+.se-stats-breakdown {
+    display: flex;
+    flex-direction: column;
+    gap: 6px
+}
+
+.se-stats-components {
+    display: grid;
+    gap: 10px;
+    padding: 14px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, .02)
+}
+
+.se-stats-components-title {
+    font-size: 11px;
+    color: var(--etica);
+    letter-spacing: .08em;
+    text-transform: uppercase
+}
+
+.se-component-row {
+    display: grid;
+    grid-template-columns: 150px 1fr 40px;
+    gap: 10px;
+    align-items: center
+}
+
+.se-component-label,
+.se-component-val {
+    font-size: 11px;
+    color: var(--muted)
+}
+
+.se-component-bar {
+    height: 6px;
+    background: rgba(255, 255, 255, .06);
+    border-radius: 999px;
+    overflow: hidden
+}
+
+.se-component-fill {
+    height: 100%;
+    border-radius: inherit
+}
+
+.se-stat-row {
+    display: flex;
+    align-items: center;
+    gap: 10px
+}
+
+.se-stat-label {
+    font-size: 11px;
+    min-width: 120px;
+    white-space: nowrap
+}
+
+.se-stat-bar {
+    flex: 1;
+    height: 3px;
+    background: rgba(255, 255, 255, .06);
+    border-radius: 2px;
+    overflow: hidden
+}
+
+.se-stat-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width .6s ease
+}
+
+.se-stat-val {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--muted);
+    min-width: 24px;
+    text-align: right
+}
+
+.se-stats-empty {
+    color: var(--muted);
+    font-size: 14px;
+    text-align: center;
+    padding: 20px
+}
+
+
+/* Result cards */
+
+.se-results-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 16px
+}
+
+.se-card {
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 20px;
+    transition: all .2s;
+    display: flex;
+    flex-direction: column;
+    gap: 10px
+}
+
+.se-card:hover {
+    border-color: rgba(255, 255, 255, .15);
+    transform: translateY(-2px)
+}
+
+.se-card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px
+}
+
+.se-card-icon {
+    font-size: 16px
+}
+
+.se-card-fuente {
+    font-size: 10px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    font-weight: 600
+}
+
+.se-card-fecha {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--dim)
+}
+
+.se-card-title {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--text)
+}
+
+.se-card-capa {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.55;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden
+}
+
+.se-card-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px
+}
+
+.se-pill {
+    border-radius: 999px;
+    padding: 3px 8px;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    border: 1px solid transparent
+}
+
+.se-pill--oficial {
+    background: rgba(74, 127, 165, .16);
+    border-color: rgba(74, 127, 165, .28);
+    color: #9fc3dd
+}
+
+.se-pill--academica {
+    background: rgba(208, 111, 156, .14);
+    border-color: rgba(208, 111, 156, .28);
+    color: #f0bdd4
+}
+
+.se-pill--ok {
+    background: rgba(122, 158, 110, .15);
+    border-color: rgba(122, 158, 110, .34);
+    color: #b9d7ac
+}
+
+.se-pill--warn {
+    background: rgba(216, 167, 90, .12);
+    border-color: rgba(216, 167, 90, .28);
+    color: #f3cd95
+}
+
+.se-pill--score {
+    background: rgba(200, 169, 110, .12);
+    border-color: rgba(200, 169, 110, .3);
+    color: #e6cb95
+}
+
+.se-card-freshness {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap
+}
+
+.se-pill-muted {
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    padding: 2px 8px;
+    font-size: 10px;
+    color: var(--dim)
+}
+
+.se-card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px
+}
+
+.se-card-score-wrap {
+    display: flex;
+    align-items: center;
+    gap: 8px
+}
+
+.se-card-score-label {
+    font-size: 10px;
+    color: var(--dim);
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    min-width: 52px
+}
+
+.se-card-score-bar {
+    flex: 1;
+    height: 4px;
+    background: rgba(255, 255, 255, .06);
+    border-radius: 2px;
+    overflow: hidden
+}
+
+.se-card-score-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width .8s cubic-bezier(.4, 0, .2, 1)
+}
+
+.se-card-score-val {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    font-weight: 700;
+    min-width: 36px;
+    text-align: right
+}
+
+.se-card-caso {
+    font-size: 11px;
+    color: var(--dim);
+    padding: 4px 0 0
+}
+
+.se-card-audit {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, .025);
+    border-radius: 6px
+}
+
+.se-card-audit-head {
+    display: flex;
+    flex-direction: column;
+    gap: 4px
+}
+
+.se-card-audit-kicker {
+    font-size: 10px;
+    color: var(--etica);
+    letter-spacing: .08em;
+    text-transform: uppercase
+}
+
+.se-card-audit-summary {
+    font-size: 11px;
+    color: var(--muted);
+    line-height: 1.5
+}
+
+.se-card-audit-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px
+}
+
+.se-card-audit-metric,
+.se-audit-pill {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 3px 7px;
+    background: rgba(255, 255, 255, .03)
+}
+
+.se-card-audit-markers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px
+}
+
+.se-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px
+}
+
+.se-card-details {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, .02)
+}
+
+.se-card-details summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--muted);
+    font-size: 12px
+}
+
+.se-card-details summary::-webkit-details-marker {
+    display: none
+}
+
+.se-card-details[open] summary {
+    color: var(--text)
+}
+
+.se-card-details-body {
+    padding: 0 12px 12px;
+    display: grid;
+    gap: 10px
+}
+
+.se-card-details-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px
+}
+
+.se-card-detail-box {
+    border: 1px solid rgba(255, 255, 255, .06);
+    border-radius: 6px;
+    padding: 8px 9px;
+    background: rgba(255, 255, 255, .018)
+}
+
+.se-card-detail-kicker {
+    display: block;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--dim);
+    margin-bottom: 4px
+}
+
+.se-card-detail-value {
+    font-size: 12px;
+    color: var(--text)
+}
+
+.se-card-detail-note {
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--muted)
+}
+
+.se-card-marker-list,
+.se-card-shared-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px
+}
+
+.se-card-marker-pill,
+.se-card-shared-pill {
+    border-radius: 999px;
+    padding: 5px 8px;
+    font-size: 11px
+}
+
+.se-card-marker-pill {
+    background: rgba(200, 95, 74, .12);
+    color: #efb2a4;
+    border: 1px solid rgba(200, 95, 74, .24)
+}
+
+.se-card-shared-pill {
+    background: rgba(74, 127, 165, .1);
+    color: #9fc3dd;
+    border: 1px solid rgba(74, 127, 165, .22)
+}
+
+.se-tag {
+    font-size: 10px;
+    padding: 2px 8px;
+    background: rgba(255, 255, 255, .04);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--dim)
+}
+
+.se-card-link {
+    font-size: 11px;
+    color: var(--etica);
+    text-decoration: none;
+    transition: opacity .15s;
+    margin-top: auto;
+    padding-top: 4px
+}
+
+.se-card-link:hover {
+    opacity: .7
+}
+
+.se-no-results {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--muted);
+    padding: 40px 20px;
+    font-size: 14px
+}
+
+@media(max-width:768px) {
+    .se-search-bar {
+        flex-direction: column
+    }
+    .se-facets-head {
+        align-items: flex-start
+    }
+    .se-results-grid {
+        grid-template-columns: 1fr
+    }
+    .se-stats-summary {
+        gap: 16px
+    }
+    .se-component-row {
+        grid-template-columns: 110px 1fr 34px;
+        gap: 8px
+    }
+    .se-card-details-grid {
+        grid-template-columns: 1fr
+    }
+    .se-stats-components {
+        padding: 12px
+    }
+}
+
+
+/* ═══════════════ PRINT STYLESHEET ═══════════════ */
+
+@media print {
+     :root {
+        --bg: #fff;
+        --s1: #fff;
+        --s2: #f5f5f5;
+        --text: #111;
+        --muted: #555;
+        --border: #ddd;
+    }
+    body {
+        background: #fff;
+        color: #111;
+        font-size: 11pt;
+        line-height: 1.6;
+    }
+    .hero {
+        min-height: auto;
+        padding: 40px 20px;
+    }
+    .hero h1 {
+        font-size: 24pt;
+        color: #111;
+    }
+    .hero-subtitle {
+        color: #333;
+    }
+    .top-nav,
+    .bottom-nav,
+    .scroll-top-fab,
+    .hero-ctas,
+    .graph-wrap,
+    #campo-social-wrap,
+    .sf-controls,
+    .social-field-canvas,
+    #graph-controls,
+    .gc-btn,
+    .sf-btn,
+    .ts-toggle,
+    footer {
+        display: none !important;
+    }
+    .section {
+        break-inside: avoid;
+        padding: 20px 0;
+    }
+    .section h2 {
+        font-size: 16pt;
+        color: #111;
+        border-bottom: 1px solid #333;
+    }
+    .tv-capa {
+        border: 1px solid #ccc;
+        break-inside: avoid;
+    }
+    .tvc-title {
+        color: #111;
+    }
+    .kw {
+        background: #eee;
+        color: #333;
+        border: 1px solid #ccc;
+    }
+    a {
+        color: #111;
+        text-decoration: underline;
+    }
+    a::after {
+        content: " (" attr(href) ")";
+        font-size: 8pt;
+        color: #666;
+    }
+    a[href^="#"]::after {
+        content: none;
+    }
+}
+
+/* ── Gate form interactive states (!important overrides inline styles) ── */
+#ca-gate-input:focus { border-color: #7a6340 !important; }
+#ca-gate-form button[type="submit"]:hover { background: #b8966a !important; }
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/styles/graph.css
+++ b/styles/graph.css
@@ -1,0 +1,1650 @@
+/*
+ * graph.css — Sistema de diseño del grafo de fricción
+ * Contra-Archivo · Epistemological Interface
+ *
+ * Tokens base heredados de styles.css:
+ *   --color-bg, --color-surface, --color-border,
+ *   --color-accent, --color-text, --font-mono, --font-serif
+ *
+ * Tokens propios del sistema de grafo:
+ *   --ca-color-etica:        #c8a96e  (dorado — testimonio)
+ *   --ca-color-institucional:#4a7fa5  (azul   — registro)
+ *   --ca-color-material:     #7a9e6e  (verde   — territorio)
+ *   --ca-friction-low:       #4a7fa5
+ *   --ca-friction-mid:       #9e7a40
+ *   --ca-friction-high:      #c8a96e
+ *   --ca-friction-critical:  #e8c47a
+ */
+
+
+/* ══════════════════════════════════════════════════════
+   TOKENS LOCALES
+══════════════════════════════════════════════════════ */
+
+:root {
+    --ca-color-etica: #c8a96e;
+    --ca-color-institucional: #4a7fa5;
+    --ca-color-material: #7a9e6e;
+    --ca-friction-low: #4a7fa5;
+    --ca-friction-mid: #b8922e;
+    --ca-friction-high: #c8a96e;
+    --ca-friction-critical: #e8c47a;
+    --ca-panel-width: 420px;
+    --ca-panel-mobile-height: 60vh;
+    --ca-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    /* Tokens base: fallback para páginas que no cargan styles.css */
+    --color-bg: #0d0d0d;
+    --color-surface: #1a1a1a;
+    --color-border: #2e2e2e;
+    --color-accent: #c8a96e;
+    --color-accent-dim: #7a6340;
+    --color-accent-subtle: rgba(200, 169, 110, 0.04);
+    --color-text: #e8e0d0;
+    --color-text-muted: #9e9484;
+    --font-mono: 'Courier New', monospace;
+    --font-serif: 'Georgia', 'Times New Roman', serif;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   MODO GRAFO — CONTENEDOR PRINCIPAL
+══════════════════════════════════════════════════════ */
+
+#graph-mode-section {
+    display: none;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+    background: var(--color-bg);
+}
+
+#graph-mode-section.ca-active {
+    display: flex;
+}
+
+
+/* ── Toggle entre modos ── */
+
+.ca-mode-toggle {
+    position: fixed;
+    top: calc(2px + 2.5rem + 0.75rem);
+    /* debajo del nav sticky */
+    right: 1rem;
+    z-index: 400;
+    display: flex;
+    gap: 2px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    padding: 2px;
+    border-radius: 4px;
+}
+
+.ca-mode-btn {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: none;
+    padding: 0.4rem 0.8rem;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: background var(--ca-transition), color var(--ca-transition);
+}
+
+.ca-mode-btn.active {
+    background: var(--color-accent-dim);
+    color: var(--color-accent);
+}
+
+.ca-mode-btn:hover:not(.active) {
+    color: var(--color-text);
+}
+
+
+/* ══════════════════════════════════════════════════════
+   TOOLBAR DEL GRAFO
+══════════════════════════════════════════════════════ */
+
+.ca-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg);
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+.ca-toolbar__group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.ca-toolbar__label {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+
+/* Filtros de capa */
+
+.ca-layer-filter {
+    display: flex;
+    gap: 2px;
+}
+
+.ca-layer-btn {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 0.3rem 0.65rem;
+    cursor: pointer;
+    transition: all var(--ca-transition);
+    white-space: nowrap;
+}
+
+.ca-layer-btn:hover {
+    color: var(--color-text);
+}
+
+.ca-layer-btn[data-layer="etica"].active {
+    border-color: var(--ca-color-etica);
+    color: var(--ca-color-etica);
+    background: rgba(200, 169, 110, 0.08);
+}
+
+.ca-layer-btn[data-layer="institucional"].active {
+    border-color: var(--ca-color-institucional);
+    color: var(--ca-color-institucional);
+    background: rgba(74, 127, 165, 0.08);
+}
+
+.ca-layer-btn[data-layer="material"].active {
+    border-color: var(--ca-color-material);
+    color: var(--ca-color-material);
+    background: rgba(122, 158, 110, 0.08);
+}
+
+.ca-layer-btn[data-layer="all"].active {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+
+/* Filtros de fricción */
+
+.ca-friction-filter {
+    display: flex;
+    gap: 2px;
+}
+
+.ca-friction-btn {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 0.3rem 0.6rem;
+    cursor: pointer;
+    transition: all var(--ca-transition);
+}
+
+.ca-friction-btn:hover {
+    color: var(--color-text);
+}
+
+.ca-friction-btn.active {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    background: var(--color-accent-subtle);
+}
+
+
+/* ── Separador ── */
+
+.ca-toolbar__sep {
+    width: 1px;
+    height: 24px;
+    background: var(--color-border);
+}
+
+
+/* ── Leyenda de intensidad ── */
+
+.ca-intensity-legend {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+}
+
+.ca-intensity-legend__bar {
+    width: 80px;
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(to right, var(--ca-friction-low), var(--ca-friction-mid), var(--ca-friction-high), var(--ca-friction-critical));
+}
+
+.ca-intensity-legend__label {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    color: var(--color-text-muted);
+}
+
+
+/* ══════════════════════════════════════════════════════
+   ÁREA DEL GRAFO
+══════════════════════════════════════════════════════ */
+
+.ca-graph-area {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+.ca-graph-canvas {
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+}
+
+
+/* ── Canvas del campo de fuerzas (detrás del SVG) ── */
+
+.friction-field-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.friction-graph-svg {
+    position: relative;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+}
+
+.friction-graph-svg:active {
+    cursor: grabbing;
+}
+
+
+/* ── SVG: Links ── */
+
+.ca-link {
+    stroke: var(--color-border);
+    stroke-opacity: 0.6;
+    transition: stroke 0.2s, stroke-opacity 0.2s;
+}
+
+.ca-link--active {
+    stroke: var(--color-accent-dim);
+    stroke-opacity: 0.9;
+}
+
+.ca-link--dimmed {
+    stroke-opacity: 0.15;
+}
+
+
+/* ── SVG: Nodos ── */
+
+.ca-node {
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.ca-node:focus-visible {
+    outline: none;
+    /* manejado por el anillo de tipo */
+}
+
+.ca-node:focus-visible .ca-hitbox {
+    stroke: var(--color-accent);
+    stroke-width: 2;
+    fill: rgba(200, 169, 110, 0.05);
+}
+
+.ca-node--hovered {
+    filter: brightness(1.15);
+}
+
+.ca-node--selected .ca-friction-center {
+    stroke: var(--color-accent);
+    stroke-width: 2;
+}
+
+.ca-node--dimmed {
+    opacity: 0.2;
+    pointer-events: none;
+}
+
+.ca-layer-circle {
+    transition: opacity var(--ca-transition);
+}
+
+.ca-friction-center {
+    transition: r 0.3s ease;
+}
+
+
+/* ── SVG: Labels ── */
+
+.ca-label text {
+    fill: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    pointer-events: none;
+    user-select: none;
+    transition: opacity 0.2s;
+}
+
+.ca-node--selected+.ca-label text,
+.ca-node--hovered+.ca-label text {
+    fill: var(--color-accent);
+}
+
+.ca-node--dimmed+.ca-label text {
+    opacity: 0.15;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   PREVIEW (HOVER)
+══════════════════════════════════════════════════════ */
+
+.ca-preview {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    max-width: 280px;
+    background: rgba(26, 26, 26, 0.96);
+    border: 1px solid var(--color-border);
+    border-top: 2px solid var(--color-accent-dim);
+    padding: 1rem;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity var(--ca-transition), transform var(--ca-transition);
+    z-index: 100;
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+}
+
+.ca-preview--visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.ca-preview__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.5rem;
+}
+
+.ca-preview__titulo {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text);
+    line-height: 1.3;
+}
+
+.ca-preview__anio {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    margin-left: 0.5rem;
+}
+
+.ca-preview__friction {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.4rem;
+}
+
+.ca-preview__friction-bar {
+    flex: 1;
+    height: 3px;
+    background: var(--color-border);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.ca-preview__friction-fill {
+    height: 100%;
+    background: linear-gradient(to right, var(--ca-friction-mid), var(--ca-friction-critical));
+    border-radius: 2px;
+    transition: width 0.3s ease;
+}
+
+.ca-preview__friction-label {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    color: var(--color-accent);
+    white-space: nowrap;
+}
+
+.ca-preview__tipo {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    color: var(--color-text-muted);
+    margin-bottom: 0.4rem;
+    line-height: 1.3;
+}
+
+.ca-preview__tension {
+    font-family: var(--font-serif);
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text);
+    line-height: 1.5;
+    margin-bottom: 0.6rem;
+    padding-left: 0.5rem;
+    border-left: 2px solid var(--color-accent-dim);
+}
+
+.ca-preview__layers {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 0.5rem;
+}
+
+.ca-preview__layer-chip {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    border: 1px solid;
+    padding: 2px 6px;
+    border-radius: 2px;
+    font-family: var(--font-mono);
+    font-size: 0.5rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    flex: 1;
+}
+
+.ca-preview__layer-icon {
+    font-size: 0.7rem;
+    flex-shrink: 0;
+}
+
+.ca-preview__hint {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    color: var(--color-text-muted);
+    text-align: right;
+    letter-spacing: 0.05em;
+    margin: 0;
+}
+
+
+/* ── Preview: Link tooltip ── */
+
+.ca-preview__link-nodes {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.5rem;
+}
+
+.ca-preview__link-node {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.05em;
+    color: var(--color-text);
+    line-height: 1.3;
+    flex: 1;
+}
+
+.ca-preview__link-arrow {
+    color: var(--color-accent-dim);
+    font-size: 0.8rem;
+    flex-shrink: 0;
+}
+
+.ca-preview__link-shared {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.ca-preview__link-tag {
+    font-family: var(--font-mono);
+    font-size: 0.5rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    padding: 2px 5px;
+    border-radius: 2px;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   PANEL DE DETALLE
+══════════════════════════════════════════════════════ */
+
+.ca-panel {
+    width: var(--ca-panel-width);
+    flex-shrink: 0;
+    background: var(--color-surface);
+    border-left: 1px solid var(--color-border);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    transform: translateX(100%);
+    opacity: 0;
+    visibility: hidden;
+    transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.3s ease, visibility 0s 0.3s;
+}
+
+.ca-panel--open {
+    visibility: visible;
+    transform: translateX(0);
+    opacity: 1;
+    transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.3s ease, visibility 0s 0s;
+}
+
+.ca-panel__header {
+    padding: 1.5rem 1.5rem 0;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 1rem;
+    position: relative;
+}
+
+.ca-panel__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: color var(--ca-transition), border-color var(--ca-transition);
+}
+
+.ca-panel__close:hover {
+    color: var(--color-text);
+    border-color: var(--color-accent-dim);
+}
+
+.ca-panel__meta {
+    margin-bottom: 0.5rem;
+}
+
+.ca-panel__label {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+}
+
+.ca-panel__titulo {
+    font-size: 1rem;
+    font-weight: normal;
+    letter-spacing: 0.02em;
+    color: var(--color-text);
+    line-height: 1.4;
+    margin-bottom: 1rem;
+    padding-right: 2rem;
+}
+
+
+/* Barra de fricción */
+
+.ca-panel__friction-block {
+    margin-bottom: 1rem;
+}
+
+.ca-panel__friction-bar {
+    height: 4px;
+    background: var(--color-border);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 0.4rem;
+}
+
+.ca-panel__friction-fill {
+    height: 100%;
+    background: linear-gradient(to right, var(--ca-friction-mid), var(--ca-friction-critical));
+    border-radius: 2px;
+}
+
+.ca-panel__friction-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.ca-panel__friction-pct {
+    font-family: var(--font-mono);
+    font-size: 1.1rem;
+    color: var(--color-accent);
+    font-weight: bold;
+}
+
+.ca-panel__friction-tipo {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.05em;
+    text-align: right;
+    max-width: 60%;
+}
+
+.ca-panel__friction-subtipo {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    color: var(--color-text-muted);
+    margin-top: 0.2rem;
+}
+
+
+/* Blockquote de tensión central */
+
+.ca-panel__tension {
+    background: rgba(200, 169, 110, 0.05);
+    border-left: 3px solid var(--color-accent-dim);
+    padding: 0.75rem 1rem;
+    margin: 0 0 1rem;
+    border-radius: 0 4px 4px 0;
+}
+
+.ca-panel__tension p {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 0.85rem;
+    color: var(--color-text);
+    margin: 0 0 0.3rem;
+    max-width: none;
+}
+
+.ca-panel__tension cite {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    color: var(--color-accent-dim);
+    font-style: normal;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+
+/* Tags */
+
+.ca-panel__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 0;
+}
+
+.ca-panel__tag {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    padding: 2px 6px;
+    border-radius: 2px;
+}
+
+
+/* ── Tabs de capa ── */
+
+.ca-panel__layer-nav {
+    display: flex;
+    border-bottom: 1px solid var(--color-border);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.ca-panel__layer-nav::-webkit-scrollbar {
+    display: none;
+}
+
+.ca-panel__tab {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.6rem 1rem;
+    cursor: pointer;
+    transition: color var(--ca-transition), border-color var(--ca-transition);
+    white-space: nowrap;
+}
+
+.ca-panel__tab:hover {
+    color: var(--color-text);
+}
+
+.ca-panel__tab--active {
+    color: var(--tab-color, var(--color-accent));
+    border-bottom-color: var(--tab-color, var(--color-accent));
+}
+
+
+/* ── Capas ── */
+
+.ca-panel__layers-body {
+    background: var(--color-bg);
+}
+
+.ca-panel__layer {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+    border-left: 3px solid var(--layer-color, var(--color-border));
+}
+
+.ca-panel__layer[hidden] {
+    display: none;
+}
+
+.ca-panel__layer-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.ca-panel__layer-icon {
+    font-size: 1.2rem;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.ca-panel__layer-title {
+    font-size: 0.85rem;
+    font-weight: bold;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin: 0 0 0.1rem;
+}
+
+.ca-panel__layer-sublabel {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.1em;
+    margin: 0;
+}
+
+.ca-panel__layer-nombre {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin: 0 0 0.6rem;
+}
+
+.ca-panel__layer-desc {
+    font-family: var(--font-serif);
+    font-size: 0.82rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    margin: 0 0 0.75rem;
+    max-width: none;
+}
+
+.ca-panel__voces-title,
+.ca-panel__docs-title {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin: 0 0 0.4rem;
+}
+
+.ca-panel__voces-list,
+.ca-panel__docs-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.75rem;
+}
+
+.ca-panel__voces-list li,
+.ca-panel__docs-list li {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--color-text-muted);
+    padding: 0.3rem 0;
+    border-bottom: 1px solid var(--color-border);
+    line-height: 1.5;
+}
+
+.ca-panel__voces-list li::before {
+    content: '″ ';
+    color: var(--ca-color-etica);
+}
+
+.ca-panel__docs-list li::before {
+    content: '→ ';
+    color: var(--color-text-muted);
+}
+
+.ca-panel__keywords {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 0.5rem;
+}
+
+.ca-panel__keyword {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.08em;
+    border: 1px solid;
+    padding: 2px 6px;
+    border-radius: 2px;
+    opacity: 0.8;
+}
+
+
+/* ── Zona de fricción ── */
+
+.ca-panel__friction-detail {
+    padding: 1.25rem 1.5rem;
+    background: rgba(200, 169, 110, 0.03);
+    border-top: 1px solid var(--color-border);
+}
+
+.ca-panel__friction-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.ca-panel__friction-icon {
+    font-size: 1rem;
+}
+
+.ca-panel__friction-header h3 {
+    font-size: 0.75rem;
+    font-weight: bold;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text);
+    margin: 0;
+    flex: 1;
+}
+
+.ca-panel__estado {
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: 2px;
+    border: 1px solid;
+}
+
+.ca-panel__estado--abierta {
+    color: var(--ca-friction-critical);
+    border-color: var(--ca-friction-critical);
+    background: rgba(232, 196, 122, 0.06);
+}
+
+.ca-panel__marcadores {
+    list-style: none;
+    padding: 0;
+    margin: 0.5rem 0;
+}
+
+.ca-panel__audit {
+    margin: 0.9rem 0 1rem;
+    padding: 0.85rem;
+    border: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.ca-panel__audit-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.ca-panel__audit-kicker,
+.ca-panel__audit-label,
+.ca-panel__audit-pair-bars,
+.ca-panel__audit-note,
+.ca-panel__audit-pair-empty {
+    font-family: var(--font-mono);
+}
+
+.ca-panel__audit-kicker {
+    display: block;
+    font-size: 0.55rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    margin-bottom: 0.2rem;
+}
+
+.ca-panel__audit-source,
+.ca-panel__audit-summary {
+    margin: 0;
+    font-size: 0.72rem;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+}
+
+.ca-panel__audit-score {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    color: var(--ca-friction-critical);
+}
+
+.ca-panel__audit-metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.ca-panel__audit-metric {
+    padding: 0.55rem;
+    border: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.ca-panel__audit-label {
+    display: block;
+    font-size: 0.5rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin-bottom: 0.3rem;
+}
+
+.ca-panel__audit-metric strong {
+    font-size: 0.82rem;
+    color: var(--color-text);
+}
+
+.ca-panel__audit-note {
+    margin: 0.65rem 0 0;
+    padding: 0.55rem 0.65rem;
+    font-size: 0.58rem;
+    line-height: 1.5;
+    color: var(--ca-friction-critical);
+    border-left: 2px solid var(--ca-friction-critical);
+    background: rgba(200, 95, 74, 0.08);
+}
+
+.ca-panel__audit-pairs {
+    display: grid;
+    gap: 0.55rem;
+    margin-top: 0.75rem;
+}
+
+.ca-panel__audit-pair {
+    padding: 0.65rem;
+    border: 1px solid var(--color-border);
+    background: rgba(0, 0, 0, 0.12);
+}
+
+.ca-panel__audit-pair-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+
+.ca-panel__audit-pair-label {
+    font-size: 0.72rem;
+    color: var(--color-text);
+}
+
+.ca-panel__audit-pair-score {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--color-accent);
+}
+
+.ca-panel__audit-pair-bars {
+    display: flex;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+    font-size: 0.52rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+
+.ca-panel__audit-pair-markers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+}
+
+.ca-panel__audit-pill {
+    font-family: var(--font-mono);
+    font-size: 0.52rem;
+    letter-spacing: 0.05em;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: 0.2rem 0.35rem;
+    background: rgba(200, 169, 110, 0.06);
+}
+
+.ca-panel__audit-pair-empty {
+    margin-top: 0.45rem;
+    font-size: 0.56rem;
+    line-height: 1.5;
+    color: var(--color-text-muted);
+}
+
+.ca-panel__marcador {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--color-text-muted);
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.ca-panel__marcador::before {
+    content: '⟷ ';
+    color: var(--color-accent-dim);
+}
+
+.ca-panel__no-conclusion {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-accent-dim);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.04em;
+    line-height: 1.5;
+    background: var(--color-surface);
+}
+
+@media (max-width: 640px) {
+    .ca-panel__audit-metrics {
+        grid-template-columns: 1fr;
+    }
+}
+
+.ca-panel__nc-icon {
+    font-size: 1.2rem;
+    color: var(--color-accent-dim);
+    flex-shrink: 0;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   LEYENDA DEL GRAFO
+══════════════════════════════════════════════════════ */
+
+.ca-legend {
+    position: absolute;
+    bottom: 1rem;
+    left: 1rem;
+    background: rgba(26, 26, 26, 0.92);
+    border: 1px solid var(--color-border);
+    padding: 0.75rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.08em;
+    z-index: 100;
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+}
+
+.ca-legend__title {
+    color: var(--color-accent);
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.ca-legend__item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-text-muted);
+    margin-bottom: 0.25rem;
+}
+
+.ca-legend__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.ca-legend__line {
+    width: 20px;
+    height: 2px;
+    flex-shrink: 0;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   ESTADO VACÍO / CARGANDO
+══════════════════════════════════════════════════════ */
+
+.ca-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-align: center;
+    gap: 1rem;
+}
+
+.ca-empty-state__icon {
+    font-size: 2rem;
+    opacity: 0.3;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   RESPONSIVE MOBILE ≤ 768px
+══════════════════════════════════════════════════════ */
+
+@media (max-width: 768px) {
+     :root {
+        --ca-panel-width: 100%;
+    }
+    .ca-toolbar {
+        padding: 0.6rem 1rem;
+        gap: 0.5rem;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        flex-wrap: nowrap;
+    }
+    .ca-toolbar::-webkit-scrollbar {
+        display: none;
+    }
+    .ca-toolbar__sep {
+        display: none;
+    }
+    .ca-intensity-legend {
+        display: none;
+    }
+    .ca-graph-area {
+        flex-direction: column;
+    }
+    .ca-panel {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        height: var(--ca-panel-mobile-height);
+        border-left: none;
+        border-top: 1px solid var(--color-accent-dim);
+        border-radius: 16px 16px 0 0;
+        transform: translateY(100%);
+        z-index: 500;
+    }
+    .ca-panel--open {
+        transform: translateY(0);
+    }
+    .ca-mode-toggle {
+        top: auto;
+        bottom: calc(64px + env(safe-area-inset-bottom, 0px) + 0.75rem);
+        right: 0.75rem;
+    }
+    .ca-preview {
+        max-width: calc(100vw - 2rem);
+        left: 1rem;
+        right: 1rem;
+        top: auto;
+        bottom: 0.5rem;
+    }
+    .ca-legend {
+        bottom: auto;
+        top: 0.5rem;
+        left: 0.5rem;
+        right: auto;
+        padding: 0.4rem 0.6rem;
+        font-size: 0.5rem;
+        flex-direction: row;
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+    .ca-legend__title {
+        margin-bottom: 0;
+        margin-right: 0.25rem;
+    }
+    .ca-legend__item {
+        margin-bottom: 0;
+        gap: 0.25rem;
+    }
+    .ca-legend__item:last-child {
+        display: none;
+    }
+    .ca-legend__dot {
+        width: 8px;
+        height: 8px;
+    }
+    /* Bottom sheet handle for mobile panel */
+    .ca-panel--open::before {
+        content: '';
+        display: block;
+        width: 36px;
+        height: 4px;
+        background: var(--color-text-muted);
+        border-radius: 2px;
+        margin: 0.5rem auto 0;
+        opacity: 0.55;
+    }
+}
+
+
+/* ══════════════════════════════════════════════════════
+   HIGH CONTRAST
+══════════════════════════════════════════════════════ */
+
+.high-contrast .ca-toolbar,
+.high-contrast .ca-panel,
+.high-contrast .ca-preview,
+.high-contrast .ca-legend {
+    background: #000;
+    border-color: #fff;
+}
+
+.high-contrast .ca-layer-btn.active,
+.high-contrast .ca-friction-btn.active {
+    color: #fff;
+    border-color: #fff;
+    background: #333;
+}
+
+.high-contrast .ca-link {
+    stroke: #666;
+}
+
+.high-contrast .ca-link--active {
+    stroke: #fff;
+}
+
+
+/* ══════════════════════════════════════════════════════
+   REDUCED MOTION
+══════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+    .ca-panel,
+    .ca-preview,
+    .ca-layer-circle,
+    .ca-link {
+        transition: none !important;
+    }
+    .friction-field-canvas {
+        display: none !important;
+    }
+}
+
+
+/* ══════════════════════════════════════════════════════
+   CONTROLES DE CAMPO DE FUERZAS
+══════════════════════════════════════════════════════ */
+
+.ca-field-controls {
+    display: flex;
+    gap: 2px;
+}
+
+.ca-field-btn {
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    letter-spacing: 0.06em;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+    transition: all var(--ca-transition);
+    white-space: nowrap;
+}
+
+.ca-field-btn:hover {
+    color: var(--color-text);
+}
+
+.ca-field-btn.active {
+    border-color: var(--ca-friction-high);
+    color: var(--ca-friction-high);
+    background: rgba(200, 169, 110, 0.08);
+}
+
+.ca-field-btn:not(.active) {
+    opacity: 0.5;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   BLACK-SCHOLES — Panel de valoración epistémica
+   ∂V/∂t + rS·∂V/∂S + ½σ²S²·∂²V/∂S² − rV = 0
+══════════════════════════════════════════════════════════════════════════ */
+
+.ca-panel__bs {
+    padding: 1.25rem 1.5rem;
+    border-top: 1px solid rgba(200, 169, 110, 0.25);
+    background: rgba(200, 169, 110, 0.02);
+}
+
+.ca-panel__bs-head {
+    margin-bottom: 1rem;
+}
+
+.ca-panel__bs-title-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.6rem;
+}
+
+.ca-panel__bs-icon {
+    font-family: var(--font-mono);
+    font-size: 1.4rem;
+    color: var(--ca-friction-high);
+    opacity: 0.7;
+    line-height: 1;
+    padding-top: 0.1rem;
+}
+
+.ca-panel__bs-kicker {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.55rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin-bottom: 0.15rem;
+}
+
+.ca-panel__bs-heading {
+    font-size: 0.78rem;
+    font-weight: bold;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ca-friction-high);
+    margin: 0;
+}
+
+.ca-panel__bs-desc {
+    font-size: 0.68rem;
+    color: var(--color-text-muted);
+    line-height: 1.55;
+    margin: 0;
+}
+
+/* Bloque principal: probabilidad + moneyness */
+.ca-panel__bs-main {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.ca-panel__bs-prob-block {
+    flex: 1;
+}
+
+.ca-panel__bs-prob-bar-wrap {
+    height: 4px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 0.3rem;
+}
+
+.ca-panel__bs-prob-bar {
+    height: 100%;
+    background: linear-gradient(to right, var(--ca-friction-low), var(--ca-friction-high));
+    border-radius: 2px;
+    transition: width 0.4s ease;
+}
+
+.ca-panel__bs-prob-label {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+}
+
+.ca-panel__bs-prob-pct {
+    font-family: var(--font-mono);
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: var(--ca-friction-high);
+}
+
+.ca-panel__bs-prob-text {
+    font-size: 0.62rem;
+    color: var(--color-text-muted);
+}
+
+.ca-panel__bs-prob-text em {
+    font-style: normal;
+    font-family: var(--font-mono);
+    color: var(--ca-friction-high);
+    opacity: 0.7;
+}
+
+/* Moneyness badge */
+.ca-panel__bs-moneyness {
+    text-align: center;
+    padding: 0.4rem 0.6rem;
+    border-radius: 3px;
+    border: 1px solid;
+    min-width: 5rem;
+}
+
+.ca-panel__bs-moneyness--itm {
+    border-color: rgba(122, 158, 110, 0.5);
+    background: rgba(122, 158, 110, 0.06);
+    color: #7a9e6e;
+}
+
+.ca-panel__bs-moneyness--otm {
+    border-color: rgba(74, 127, 165, 0.4);
+    background: rgba(74, 127, 165, 0.05);
+    color: #4a7fa5;
+}
+
+.ca-panel__bs-money-val {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    font-weight: bold;
+}
+
+.ca-panel__bs-money-label {
+    font-size: 0.55rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    opacity: 0.8;
+}
+
+/* Parámetros del modelo */
+.ca-panel__bs-params {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.35rem 0.75rem;
+    margin-bottom: 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border);
+    background: rgba(255, 255, 255, 0.015);
+}
+
+.ca-panel__bs-param {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    font-size: 0.65rem;
+}
+
+.ca-panel__bs-param-sym {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: bold;
+    color: var(--ca-friction-high);
+    opacity: 0.85;
+    min-width: 0.9rem;
+}
+
+.ca-panel__bs-param-name {
+    color: var(--color-text-muted);
+    flex: 1;
+}
+
+.ca-panel__bs-param strong {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    color: var(--color-text);
+}
+
+/* Letras griegas */
+.ca-panel__bs-greeks {
+    margin-bottom: 0.75rem;
+}
+
+.ca-panel__bs-greeks-title {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin: 0 0 0.5rem;
+}
+
+.ca-panel__bs-greek-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+    .ca-panel__bs-greek-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+.ca-panel__bs-greek {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.4rem;
+    border: 1px solid var(--color-border);
+    text-align: center;
+}
+
+.ca-panel__bs-greek-sym {
+    font-family: Georgia, serif;
+    font-size: 1rem;
+    color: var(--ca-friction-high);
+    opacity: 0.8;
+    line-height: 1.2;
+}
+
+.ca-panel__bs-greek-val {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--color-text);
+    margin: 0.1rem 0;
+}
+
+.ca-panel__bs-greek-desc {
+    font-size: 0.52rem;
+    color: var(--color-text-muted);
+    line-height: 1.3;
+}
+
+/* Descomposición del valor */
+.ca-panel__bs-decomp {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.ca-panel__bs-decomp-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--color-border);
+    font-size: 0.62rem;
+}
+
+.ca-panel__bs-decomp-item span:first-child {
+    color: var(--color-text-muted);
+    margin-bottom: 0.15rem;
+}
+
+.ca-panel__bs-decomp-item span:last-child {
+    font-family: var(--font-mono);
+    color: var(--color-text);
+}
+
+/* Ecuación al pie */
+.ca-panel__bs-note {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    color: var(--color-text-muted);
+    opacity: 0.5;
+    text-align: center;
+    margin: 0;
+    letter-spacing: 0.03em;
+    border-top: 1px solid var(--color-border);
+    padding-top: 0.6rem;
+}

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -1,0 +1,422 @@
+/* ══════════════════════════════════════════════════════════════
+   shared.css — Design tokens y componentes comunes
+   Contra-Archivo · Colectivo Viento Norte
+   Usado por: landing.html, buscador.html, login.html, privado.html, tesis.html
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Tokens ── */
+:root {
+    --bg: #0c0c0c;
+    --s1: #131313;
+    --s2: #1a1a1a;
+    --s3: #222222;
+    --border: rgba(255, 255, 255, .07);
+    --text: #e2e2e2;
+    --muted: #888;
+    --dim: #767676;
+    --etica: #c8a96e;
+    --inst: #4a7fa5;
+    --mat: #7a9e6e;
+    --crit: #c85f4a;
+    --warn: #e8b84b;
+    --r: 8px;
+    --r-lg: 12px;
+    --font-sans: -apple-system, 'Helvetica Neue', sans-serif;
+    --font-mono: 'SF Mono', 'Fira Code', monospace;
+
+    /* ── Spacing (4px base) ── */
+    --sp-1: 4px;
+    --sp-2: 8px;
+    --sp-3: 12px;
+    --sp-4: 16px;
+    --sp-5: 20px;
+    --sp-6: 24px;
+    --sp-8: 32px;
+
+    /* ── Shadows ── */
+    --shadow-sm: 0 1px 2px rgba(0,0,0,.3);
+    --shadow-md: 0 4px 12px rgba(0,0,0,.4);
+    --shadow-lg: 0 8px 24px rgba(0,0,0,.5);
+
+    /* ── Z-Index ── */
+    --z-dropdown: 10;
+    --z-sticky: 20;
+    --z-overlay: 80;
+    --z-drawer: 90;
+    --z-nav: 100;
+
+    /* ── Transitions ── */
+    --ease: cubic-bezier(.4, 0, .2, 1);
+    --dur: .2s;
+    --dur-slow: .3s;
+
+    /* ── Touch ── */
+    --touch-min: 44px;
+}
+
+/* ── Reset ── */
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 15px;
+    line-height: 1.55;
+    overflow-x: hidden;
+}
+
+a {
+    color: var(--etica);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+button {
+    font-family: inherit;
+    cursor: pointer;
+    border: none;
+    background: none;
+    color: inherit;
+    font-size: inherit;
+}
+
+input, select, textarea {
+    font-family: inherit;
+    font-size: inherit;
+    color: var(--text);
+    background: var(--s2);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 8px 12px;
+    outline: none;
+    width: 100%;
+}
+
+input:focus, select:focus, textarea:focus {
+    border-color: var(--etica);
+}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar       { width: 6px; }
+::-webkit-scrollbar-track { background: var(--s1); }
+::-webkit-scrollbar-thumb { background: var(--dim); border-radius: 3px; }
+
+/* ── Skip link ── */
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+.skip-link:focus {
+    position: fixed;
+    top: 12px;
+    left: 12px;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    padding: 10px 18px;
+    background: var(--etica);
+    color: var(--bg);
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    z-index: 9999;
+    outline: 2px solid var(--bg);
+    text-decoration: none;
+}
+
+/* ── Site Header ── */
+.site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+}
+
+.site-logo {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: var(--text);
+    text-decoration: none;
+}
+
+.site-logo span {
+    color: var(--etica);
+}
+
+.site-nav {
+    display: flex;
+    gap: 20px;
+    font-size: 13px;
+    align-items: center;
+}
+
+.site-nav a {
+    color: var(--muted);
+    transition: color .2s;
+}
+
+.site-nav a:hover {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.site-nav a[aria-current="page"] {
+    color: var(--etica);
+}
+
+/* ── Nav CTA (call-to-action pill in nav) ── */
+.nav-cta {
+    background: var(--etica);
+    color: #000 !important;
+    padding: 5px 14px;
+    border-radius: var(--r);
+    font-weight: 600;
+    text-decoration: none !important;
+    transition: background .2s !important;
+}
+
+.nav-cta:hover {
+    background: #b8966a !important;
+    text-decoration: none !important;
+}
+
+.nav-cta[aria-current="page"],
+.nav-cta[aria-current="page"]:hover {
+    background: var(--etica) !important;
+    cursor: default;
+}
+
+/* ── Site Footer ── */
+.site-footer {
+    text-align: center;
+    padding: 24px;
+    border-top: 1px solid var(--border);
+    margin-top: auto;
+    font-size: 13px;
+    color: var(--dim);
+}
+
+.site-footer a {
+    color: var(--muted);
+}
+
+/* ── Badges/Pills ── */
+.badge-etica {
+    background: rgba(200, 169, 110, .15);
+    color: var(--etica);
+}
+
+.badge-inst {
+    background: rgba(74, 127, 165, .15);
+    color: var(--inst);
+}
+
+.badge-mat {
+    background: rgba(122, 158, 110, .15);
+    color: var(--mat);
+}
+
+.badge-crit {
+    background: rgba(200, 95, 74, .15);
+    color: var(--crit);
+}
+
+/* Source-specific badge colors */
+.badge-infolobby       { background: rgba(200,169,110,.18); color: var(--etica); }
+.badge-transparencia   { background: rgba(74,127,165,.18);  color: var(--inst); }
+.badge-leychile        { background: rgba(122,158,110,.18); color: var(--mat); }
+.badge-seia            { background: rgba(122,158,110,.18); color: var(--mat); }
+.badge-compraspublicas { background: rgba(200,95,74,.18);   color: var(--crit); }
+.badge-cmf             { background: rgba(74,127,165,.18);  color: var(--inst); }
+.badge-bcn             { background: rgba(122,158,110,.18); color: var(--mat); }
+.badge-etnografia      { background: rgba(200,169,110,.18); color: var(--etica); }
+
+/* ── Layer chips ── */
+.capa-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    font-weight: 600;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 4px;
+}
+
+.capa-etica         { background: rgba(200,169,110,.15); color: var(--etica); }
+.capa-institucional { background: rgba(74,127,165,.15);  color: var(--inst); }
+.capa-material      { background: rgba(122,158,110,.15); color: var(--mat); }
+
+/* ── Search Input (shared) ── */
+.search-input {
+    width: 100%;
+    padding: 14px 16px;
+    background: var(--s1);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    color: var(--text);
+    font-size: 16px;
+    transition: border-color .2s, box-shadow .2s;
+}
+
+.search-input:focus {
+    border-color: var(--etica);
+    box-shadow: 0 0 0 3px rgba(200, 169, 110, .15);
+}
+
+.search-input::placeholder {
+    color: var(--dim);
+}
+
+/* ── Friction bar ── */
+.friction-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.friction-label {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--dim);
+    min-width: 42px;
+}
+
+.friction-track {
+    flex: 1;
+    height: 4px;
+    background: var(--s2);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.friction-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width .3s ease;
+}
+
+.friction-value {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--dim);
+    min-width: 28px;
+    text-align: right;
+}
+
+/* ── Buttons ── */
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 24px;
+    background: var(--etica);
+    color: #000;
+    font-weight: 600;
+    font-size: 15px;
+    border-radius: var(--r);
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background .2s;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.btn-primary:hover {
+    background: #b8966a;
+    text-decoration: none;
+}
+
+.btn-primary:disabled {
+    opacity: .4;
+    cursor: not-allowed;
+}
+
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: var(--s2);
+    color: var(--text);
+    font-size: 13px;
+    border-radius: var(--r);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    font-family: inherit;
+    transition: background .2s, border-color .2s;
+    text-decoration: none;
+}
+
+.btn-secondary:hover {
+    background: var(--s3);
+    border-color: var(--dim);
+    text-decoration: none;
+}
+
+/* ── Utilities ── */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.hidden { display: none !important; }
+
+/* ── Accessible focus ── */
+:focus-visible {
+    outline: 2px solid var(--etica);
+    outline-offset: 2px;
+}
+
+/* ── Responsive nav ── */
+@media (max-width: 640px) {
+    .site-header {
+        padding: 12px 16px;
+    }
+
+    /* Ocultar links intermedios; mantener logo + CTA */
+    .site-nav a:not(.nav-cta) {
+        display: none;
+    }
+
+    .site-nav {
+        gap: 0;
+    }
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/styles/ui-kit.css
+++ b/styles/ui-kit.css
@@ -1,0 +1,693 @@
+/* ══════════════════════════════════════════════════════════════
+   ui-kit.css — Kit UI Público · Atomic Design System
+   Contra-Archivo · Colectivo Viento Norte
+   ──────────────────────────────────────────────────────────────
+   Jerarquía Atomic Design:
+     1. TOKENS     — Variables de diseño (colores, tipografía, espaciado, sombras)
+     2. ÁTOMOS     — Elementos mínimos (botón, badge, input, chip, pill, ícono)
+     3. MOLÉCULAS  — Composiciones de átomos (barra de fricción, search, tab-bar)
+     4. ORGANISMOS — Componentes complejos (nav, sidebar drawer, card, timeline)
+     5. UTILIDADES — Clases helper (sr-only, hidden, truncate, flex-gap)
+   ──────────────────────────────────────────────────────────────
+   Metodología: Mobile-first (min-width breakpoints)
+   Navegadores: últimos 2 años, sin polyfills
+   ══════════════════════════════════════════════════════════════ */
+
+/* ═══════════════════════════════════════
+   1. TOKENS — Design Variables
+   ═══════════════════════════════════════ */
+:root {
+  /* ── Color: Surfaces ── */
+  --tk-bg:       #0c0c0c;
+  --tk-s1:       #131313;
+  --tk-s2:       #1a1a1a;
+  --tk-s3:       #222222;
+
+  /* ── Color: Text ── */
+  --tk-text:     #e2e2e2;
+  --tk-muted:    #888;
+  --tk-dim:      #767676;
+
+  /* ── Color: Semantic — Tres Capas de Verdad ── */
+  --tk-etica:    #c8a96e;   /* Ética — testimonio situado */
+  --tk-inst:     #4a7fa5;   /* Institucional — registro oficial */
+  --tk-mat:      #7a9e6e;   /* Material — territorio / evidencia */
+
+  /* ── Color: Status ── */
+  --tk-crit:     #c85f4a;
+  --tk-warn:     #e8b84b;
+  --tk-ok:       #7a9e6e;
+
+  /* ── Color: Alpha overlays ── */
+  --tk-overlay:       rgba(0,0,0,.6);
+  --tk-etica-15:      rgba(200,169,110,.15);
+  --tk-inst-15:       rgba(74,127,165,.15);
+  --tk-mat-15:        rgba(122,158,110,.15);
+  --tk-crit-15:       rgba(200,95,74,.15);
+
+  /* ── Color: Border ── */
+  --tk-border:   rgba(255,255,255,.07);
+  --tk-border-active: rgba(255,255,255,.15);
+
+  /* ── Typography ── */
+  --tk-font-sans: -apple-system, 'Helvetica Neue', sans-serif;
+  --tk-font-mono: 'SF Mono', 'Fira Code', monospace;
+  --tk-fs-xs:    .65rem;    /* 10.4px */
+  --tk-fs-sm:    .78rem;    /* 12.5px */
+  --tk-fs-base:  .85rem;    /* 13.6px */
+  --tk-fs-md:    .95rem;    /* 15.2px */
+  --tk-fs-lg:    1.05rem;   /* 16.8px */
+  --tk-fs-xl:    1.15rem;   /* 18.4px */
+  --tk-lh:       1.55;
+
+  /* ── Spacing Scale (4px base) ── */
+  --tk-sp-1:  4px;
+  --tk-sp-2:  8px;
+  --tk-sp-3:  12px;
+  --tk-sp-4:  16px;
+  --tk-sp-5:  20px;
+  --tk-sp-6:  24px;
+  --tk-sp-8:  32px;
+  --tk-sp-10: 40px;
+  --tk-sp-12: 48px;
+  --tk-sp-16: 64px;
+
+  /* ── Radius ── */
+  --tk-r-sm:  4px;
+  --tk-r:     8px;
+  --tk-r-lg:  12px;
+  --tk-r-xl:  16px;
+  --tk-r-pill: 100px;
+  --tk-r-full: 50%;
+
+  /* ── Shadows ── */
+  --tk-shadow-sm:  0 1px 2px rgba(0,0,0,.3);
+  --tk-shadow-md:  0 4px 12px rgba(0,0,0,.4);
+  --tk-shadow-lg:  0 8px 24px rgba(0,0,0,.5);
+  --tk-shadow-xl:  0 12px 40px rgba(0,0,0,.6);
+
+  /* ── Z-Index Scale ── */
+  --tk-z-base:     1;
+  --tk-z-dropdown: 10;
+  --tk-z-sticky:   20;
+  --tk-z-overlay:  80;
+  --tk-z-drawer:   90;
+  --tk-z-nav:      100;
+  --tk-z-modal:    110;
+
+  /* ── Transitions ── */
+  --tk-ease:     cubic-bezier(.4, 0, .2, 1);
+  --tk-dur-fast: .15s;
+  --tk-dur:      .2s;
+  --tk-dur-slow: .3s;
+
+  /* ── Layout ── */
+  --tk-nav-h:    56px;
+  --tk-sidebar-w: 280px;
+  --tk-touch-min: 44px;  /* iOS HIG mínimo touch target (WCAG 2.5.8 = 24px) */
+}
+
+/*
+   ── Breakpoints (referencia para @media queries) ──
+   CSS no permite usar custom properties en @media, estos valores
+   se usan manualmente en las media queries del proyecto:
+     480px   (sm)  — Teléfonos grandes / landscape
+     768px   (md)  — Tablets
+     1024px  (lg)  — Desktop
+     1280px  (xl)  — Desktop ancho
+*/
+
+
+/* ═══════════════════════════════════════
+   2. ÁTOMOS — Elementos mínimos
+   ═══════════════════════════════════════ */
+
+/* ── Botón Primario ── */
+.uk-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tk-sp-2);
+  padding: var(--tk-sp-3) var(--tk-sp-6);
+  background: var(--tk-etica);
+  color: #000;
+  font-weight: 600;
+  font-size: var(--tk-fs-base);
+  font-family: var(--tk-font-sans);
+  border-radius: var(--tk-r);
+  border: none;
+  cursor: pointer;
+  transition: background var(--tk-dur) var(--tk-ease);
+  text-decoration: none;
+  white-space: nowrap;
+  min-height: var(--tk-touch-min);
+}
+.uk-btn-primary:hover { background: #b8966a; text-decoration: none; }
+.uk-btn-primary:disabled { opacity: .4; cursor: not-allowed; }
+
+/* ── Botón Secundario ── */
+.uk-btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tk-sp-2);
+  padding: var(--tk-sp-2) var(--tk-sp-4);
+  background: var(--tk-s2);
+  color: var(--tk-text);
+  font-size: var(--tk-fs-sm);
+  font-family: var(--tk-font-sans);
+  border-radius: var(--tk-r);
+  border: 1px solid var(--tk-border);
+  cursor: pointer;
+  transition: background var(--tk-dur) var(--tk-ease), border-color var(--tk-dur) var(--tk-ease);
+  text-decoration: none;
+  min-height: var(--tk-touch-min);
+}
+.uk-btn-secondary:hover { background: var(--tk-s3); border-color: var(--tk-dim); text-decoration: none; }
+
+/* ── Botón Ghost ── */
+.uk-btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tk-sp-2);
+  padding: var(--tk-sp-2) var(--tk-sp-3);
+  background: none;
+  color: var(--tk-muted);
+  font-size: var(--tk-fs-sm);
+  font-family: var(--tk-font-sans);
+  border-radius: var(--tk-r);
+  border: none;
+  cursor: pointer;
+  transition: color var(--tk-dur), background var(--tk-dur);
+  min-height: var(--tk-touch-min);
+}
+.uk-btn-ghost:hover { color: var(--tk-text); background: var(--tk-s2); }
+
+/* ── Badge (átomo de etiqueta semántica) ── */
+.uk-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tk-sp-1);
+  font-size: var(--tk-fs-xs);
+  font-family: var(--tk-font-mono);
+  font-weight: 600;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  padding: 2px var(--tk-sp-2);
+  border-radius: var(--tk-r-sm);
+}
+.uk-badge--etica    { background: var(--tk-etica-15); color: var(--tk-etica); }
+.uk-badge--inst     { background: var(--tk-inst-15);  color: var(--tk-inst); }
+.uk-badge--mat      { background: var(--tk-mat-15);   color: var(--tk-mat); }
+.uk-badge--crit     { background: var(--tk-crit-15);  color: var(--tk-crit); }
+
+/* ── Pill (badge redondeado para contadores) ── */
+.uk-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tk-sp-1);
+  font-size: var(--tk-fs-xs);
+  font-family: var(--tk-font-mono);
+  padding: 2px var(--tk-sp-2);
+  border-radius: var(--tk-r-pill);
+  background: var(--tk-s2);
+  color: var(--tk-muted);
+}
+
+/* ── Input ── */
+.uk-input {
+  width: 100%;
+  padding: var(--tk-sp-2) var(--tk-sp-3);
+  background: var(--tk-s2);
+  border: 1px solid var(--tk-border);
+  border-radius: var(--tk-r);
+  color: var(--tk-text);
+  font-size: var(--tk-fs-base);
+  font-family: var(--tk-font-sans);
+  outline: none;
+  transition: border-color var(--tk-dur), box-shadow var(--tk-dur);
+  min-height: var(--tk-touch-min);
+}
+.uk-input:focus {
+  border-color: var(--tk-etica);
+  box-shadow: 0 0 0 3px rgba(200,169,110,.15);
+}
+.uk-input::placeholder { color: var(--tk-dim); }
+
+/* ── Tag (micro etiqueta) ── */
+.uk-tag {
+  font-size: var(--tk-fs-xs);
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--tk-s1);
+  color: var(--tk-dim);
+  border: 1px solid var(--tk-border);
+}
+
+/* ── Mono text ── */
+.uk-mono {
+  font-family: var(--tk-font-mono);
+  font-size: var(--tk-fs-sm);
+  color: var(--tk-dim);
+}
+
+
+/* ═══════════════════════════════════════
+   3. MOLÉCULAS — Composiciones de átomos
+   ═══════════════════════════════════════ */
+
+/* ── Friction Bar ── */
+.uk-friction-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tk-sp-2);
+}
+.uk-friction-label {
+  font-size: 11px;
+  font-family: var(--tk-font-mono);
+  color: var(--tk-dim);
+  min-width: 42px;
+}
+.uk-friction-track {
+  flex: 1;
+  height: 4px;
+  background: var(--tk-s2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.uk-friction-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width var(--tk-dur-slow) var(--tk-ease);
+}
+.uk-friction-value {
+  font-size: 11px;
+  font-family: var(--tk-font-mono);
+  color: var(--tk-dim);
+  min-width: 28px;
+  text-align: right;
+}
+
+/* ── Search (input con ícono) ── */
+.uk-search-wrap {
+  position: relative;
+}
+.uk-search-wrap .uk-input {
+  padding-left: var(--tk-sp-8);
+}
+.uk-search-wrap::before {
+  content: '⌕';
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--tk-dim);
+  font-size: 1.1rem;
+  pointer-events: none;
+}
+
+/* ── Tab Bar ── */
+.uk-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--tk-border);
+  gap: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.uk-tabs::-webkit-scrollbar { height: 0; }
+.uk-tab {
+  padding: var(--tk-sp-3) var(--tk-sp-4);
+  font-size: var(--tk-fs-base);
+  color: var(--tk-muted);
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition: color var(--tk-dur), border-color var(--tk-dur);
+  cursor: pointer;
+  min-height: var(--tk-touch-min);
+  display: flex;
+  align-items: center;
+}
+.uk-tab:hover { color: var(--tk-text); }
+.uk-tab.active { color: var(--tk-etica); border-bottom-color: var(--tk-etica); }
+
+/* ── Slider Group ── */
+.uk-slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.uk-slider-group label {
+  font-size: var(--tk-fs-xs);
+  color: var(--tk-dim);
+  text-transform: uppercase;
+  letter-spacing: .4px;
+}
+.uk-slider-group input[type=range] {
+  width: 100%;
+  accent-color: var(--tk-etica);
+}
+@media (min-width: 768px) {
+  .uk-slider-group input[type=range] { width: 140px; }
+}
+
+/* ── Source Badge (fuente de datos) ── */
+.uk-source {
+  display: inline-block;
+  font-size: var(--tk-fs-xs);
+  padding: 2px var(--tk-sp-2);
+  border-radius: var(--tk-r-pill);
+  font-family: var(--tk-font-mono);
+}
+.uk-source--infolobby       { background: rgba(74,127,165,.15);  color: var(--tk-inst); }
+.uk-source--transparencia   { background: rgba(122,158,110,.15); color: var(--tk-mat); }
+.uk-source--leychile,
+.uk-source--bcn             { background: rgba(200,169,110,.15); color: var(--tk-etica); }
+.uk-source--seia            { background: rgba(200,95,74,.15);   color: var(--tk-crit); }
+.uk-source--compraspublicas { background: rgba(74,127,165,.2);   color: #6bb5e0; }
+.uk-source--cmf             { background: rgba(200,169,110,.2);  color: #dfc07a; }
+.uk-source--etnografia      { background: rgba(122,158,110,.2);  color: #9bc28b; }
+
+
+/* ═══════════════════════════════════════
+   4. ORGANISMOS — Componentes complejos
+   ═══════════════════════════════════════ */
+
+/* ── Card ── */
+.uk-card {
+  padding: var(--tk-sp-4);
+  border: 1px solid var(--tk-border);
+  border-radius: var(--tk-r);
+  transition: border-color var(--tk-dur), transform var(--tk-dur-fast);
+  display: flex;
+  flex-direction: column;
+  gap: var(--tk-sp-2);
+}
+.uk-card:hover {
+  border-color: var(--tk-dim);
+}
+.uk-card--lift:hover {
+  transform: translateY(-2px);
+}
+.uk-card__title {
+  font-size: var(--tk-fs-md);
+  font-weight: 600;
+}
+.uk-card__desc {
+  font-size: var(--tk-fs-base);
+  color: var(--tk-muted);
+  line-height: var(--tk-lh);
+}
+.uk-card__meta {
+  font-size: var(--tk-fs-sm);
+  color: var(--tk-dim);
+  font-family: var(--tk-font-mono);
+}
+
+/* ── Card Grid ── */
+.uk-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--tk-sp-4);
+}
+@media (min-width: 480px) {
+  .uk-card-grid { grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+}
+
+/* ── Drawer (sidebar móvil) ── */
+.uk-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  max-width: var(--tk-sidebar-w);
+  height: 100vh;
+  background: var(--tk-s1);
+  z-index: var(--tk-z-drawer);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  transform: translateX(-100%);
+  transition: transform var(--tk-dur-slow) var(--tk-ease);
+  padding: var(--tk-sp-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--tk-sp-5);
+}
+.uk-drawer.open {
+  transform: translateX(0);
+}
+@media (min-width: 768px) {
+  .uk-drawer {
+    position: sticky;
+    top: var(--tk-nav-h);
+    height: calc(100vh - var(--tk-nav-h));
+    transform: none;
+    border-right: 1px solid var(--tk-border);
+  }
+}
+
+/* ── Overlay (backdrop para drawer/modal) ── */
+.uk-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--tk-overlay);
+  z-index: calc(var(--tk-z-drawer) - 1);
+  -webkit-tap-highlight-color: transparent;
+}
+.uk-overlay.open { display: block; }
+
+/* ── Nav Header ── */
+.uk-nav {
+  position: sticky;
+  top: 0;
+  z-index: var(--tk-z-nav);
+  display: flex;
+  align-items: center;
+  gap: var(--tk-sp-3);
+  height: var(--tk-nav-h);
+  padding: 0 var(--tk-sp-4);
+  background: var(--tk-bg);
+  border-bottom: 1px solid var(--tk-border);
+}
+.uk-nav__logo {
+  display: flex;
+  align-items: center;
+  gap: var(--tk-sp-2);
+  font-weight: 700;
+  font-size: var(--tk-fs-lg);
+  white-space: nowrap;
+  color: var(--tk-text);
+  text-decoration: none;
+}
+.uk-nav__logo span { font-size: 1.3rem; }
+.uk-nav__links {
+  display: none;
+  gap: var(--tk-sp-2);
+  margin-left: auto;
+  align-items: center;
+}
+.uk-nav__links a,
+.uk-nav__links button {
+  font-size: var(--tk-fs-base);
+  color: var(--tk-muted);
+  padding: var(--tk-sp-2) var(--tk-sp-3);
+  border-radius: var(--tk-r);
+  transition: color var(--tk-dur), background var(--tk-dur);
+  min-height: var(--tk-touch-min);
+  display: flex;
+  align-items: center;
+}
+.uk-nav__links a:hover,
+.uk-nav__links button:hover { color: var(--tk-text); background: var(--tk-s2); text-decoration: none; }
+@media (min-width: 768px) {
+  .uk-nav__links { display: flex; }
+}
+
+/* ── Hamburger ── */
+.uk-hamburger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--tk-text);
+  font-size: 1.4rem;
+  padding: var(--tk-sp-1) var(--tk-sp-2);
+  cursor: pointer;
+  min-width: var(--tk-touch-min);
+  min-height: var(--tk-touch-min);
+}
+@media (min-width: 768px) {
+  .uk-hamburger { display: none; }
+}
+
+/* ── Timeline ── */
+.uk-timeline {
+  position: relative;
+  padding-left: var(--tk-sp-6);
+}
+.uk-timeline::before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--tk-border);
+}
+.uk-timeline__event {
+  position: relative;
+  padding: var(--tk-sp-3) var(--tk-sp-4);
+  margin-bottom: var(--tk-sp-4);
+  border: 1px solid var(--tk-border);
+  border-radius: var(--tk-r);
+  transition: border-color var(--tk-dur-fast);
+}
+.uk-timeline__event:hover { border-color: var(--tk-dim); }
+.uk-timeline__event::before {
+  content: '';
+  position: absolute;
+  left: -22px;
+  top: 16px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--tk-border);
+  background: var(--tk-s1);
+}
+@media (min-width: 768px) {
+  .uk-timeline { padding-left: var(--tk-sp-8); }
+  .uk-timeline__event::before { left: -26px; }
+}
+
+/* ── Chat ── */
+.uk-chat {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--tk-nav-h) - 120px);
+  height: calc(100dvh - var(--tk-nav-h) - 120px);
+  min-height: 300px;
+}
+.uk-chat__messages {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: var(--tk-sp-4) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--tk-sp-3);
+}
+.uk-chat__msg {
+  max-width: 85%;
+  padding: var(--tk-sp-3) var(--tk-sp-4);
+  border-radius: var(--tk-r);
+  font-size: var(--tk-fs-base);
+  line-height: var(--tk-lh);
+  word-break: break-word;
+}
+.uk-chat__msg--bot {
+  align-self: flex-start;
+  background: var(--tk-s1);
+  border-left: 3px solid var(--tk-etica);
+}
+.uk-chat__msg--user {
+  align-self: flex-end;
+  background: var(--tk-s2);
+  text-align: right;
+}
+.uk-chat__cite {
+  font-size: var(--tk-fs-sm);
+  color: var(--tk-dim);
+  margin-top: var(--tk-sp-2);
+  font-family: var(--tk-font-mono);
+}
+.uk-chat__input-row {
+  display: flex;
+  gap: var(--tk-sp-2);
+  padding-top: var(--tk-sp-3);
+  border-top: 1px solid var(--tk-border);
+}
+.uk-chat__input-row .uk-input { flex: 1; }
+@media (min-width: 768px) {
+  .uk-chat {
+    height: calc(100vh - var(--tk-nav-h) - 100px);
+    min-height: 400px;
+  }
+  .uk-chat__msg { max-width: 80%; }
+}
+
+/* ── Empty State ── */
+.uk-empty {
+  text-align: center;
+  padding: var(--tk-sp-16) var(--tk-sp-5);
+  color: var(--tk-dim);
+}
+.uk-empty__icon {
+  font-size: 2.5rem;
+  margin-bottom: var(--tk-sp-3);
+  opacity: .5;
+}
+
+/* ── News Card ── */
+.uk-news-card {
+  padding: var(--tk-sp-4);
+  border: 1px solid var(--tk-border);
+  border-radius: var(--tk-r);
+  margin-bottom: var(--tk-sp-3);
+  transition: border-color var(--tk-dur);
+}
+.uk-news-card:hover { border-color: var(--tk-dim); }
+.uk-news-card h3 { font-size: var(--tk-fs-md); margin-bottom: var(--tk-sp-2); }
+.uk-news-card .news-meta {
+  font-size: var(--tk-fs-sm);
+  color: var(--tk-dim);
+  margin-bottom: var(--tk-sp-2);
+  font-family: var(--tk-font-mono);
+}
+.uk-news-card p { font-size: var(--tk-fs-base); color: var(--tk-muted); line-height: var(--tk-lh); }
+
+
+/* ═══════════════════════════════════════
+   5. UTILIDADES
+   ═══════════════════════════════════════ */
+
+/* ── Screen reader only ── */
+.uk-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Hidden ── */
+.uk-hidden { display: none !important; }
+
+/* ── Truncate single line ── */
+.uk-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Flex utilities ── */
+.uk-flex    { display: flex; }
+.uk-flex-wrap { flex-wrap: wrap; }
+.uk-gap-1   { gap: var(--tk-sp-1); }
+.uk-gap-2   { gap: var(--tk-sp-2); }
+.uk-gap-3   { gap: var(--tk-sp-3); }
+.uk-gap-4   { gap: var(--tk-sp-4); }
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Problema

El sitio en producción (GitHub Pages) se mostraba sin ningún CSS. Todos los HTML en raíz referencian `styles/shared.css`, `styles/graph.css`, `styles/ui-kit.css` — pero ese directorio **no existía en raíz**. Solo existía en `web/styles/`. Deploy sirve desde `.` → 404 en todos los assets CSS → sitio sin diseño.

Adicionalmente, `deploy.yml` tenía `rm -rf terraza` (ruta inválida — terraza vive en `web/terraza/`), así que el código fuente Next.js nunca se excluía del artefacto.

## Cambios

- **`styles/`** creado en raíz con los 4 archivos CSS canónicos copiados desde `web/styles/`:
  - `shared.css` — tokens, reset, componentes comunes
  - `graph.css` — estilos del force graph d3
  - `ui-kit.css` — componentes UI
  - `contra-archivo.css` — estilos específicos del instrumento

- **`deploy.yml`** reforzado:
  - Nuevo paso *"Validar assets críticos"* que falla el build explícitamente si `styles/` o `src/` están ausentes → nunca más regresión silenciosa
  - Corregida exclusión: `rm -rf web` (en vez de `rm -rf terraza`) elimina correctamente el directorio fuente del artefacto público

## Test plan

- [ ] 423 tests pasan localmente (`node tests/runner.js`)
- [ ] QA Gate verde en CI
- [ ] Lighthouse puede auditar el sitio (antes fallaba por ausencia de CSS)
- [ ] Verificar en producción: `https://vientonorte.github.io/antropologia-corrupcion` carga con estilos

https://claude.ai/code/session_018SFQitGprvyE2gCRB2PwLS

---
_Generated by [Claude Code](https://claude.ai/code/session_018SFQitGprvyE2gCRB2PwLS)_