### PR TITLE
fix(poemarios): redirect /poemas.html → /Poemarios/poemas.html

### DIFF
--- a/poemas.html
+++ b/poemas.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=Poemarios/poemas.html">
+  <title>Poemarios — Contra-archivo</title>
+</head>
+<body>
+  <p>Redirigiendo… <a href="Poemarios/poemas.html">Ver poemarios →</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Qué cambia

Agrega `poemas.html` en la raíz del repositorio con un redirect instantáneo (`meta refresh`) hacia `/Poemarios/poemas.html`.

## Por qué

La URL `https://vientonorte.github.io/antropologia-corrupcion/poemas.html` daba 404 porque el archivo real vive en `/Poemarios/poemas.html`. No había ningún archivo ni redirect en la raíz para esa ruta.

## Notas para revisión

- Los archivos no rastreados (`web/terraza/tailwind.config 3.ts`, `web/zuboff-archivo 7.html`) no se incluyen en este PR — son duplicados/temporales que requieren revisión aparte.
- El fix es mínimo y no toca ningún archivo existente.