### PR TITLE
fix(poemarios): corregir rutas relativas en poemas.html

### DIFF
--- a/web/Poemarios/poemas.html
+++ b/web/Poemarios/poemas.html
@@ -11,9 +11,9 @@
     <meta property="og:type" content="website">
     <meta name="theme-color" content="#0c0c0c">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⊘</text></svg>">
-    <link rel="manifest" href="manifest.json">
-    <link rel="stylesheet" href="styles/shared.css?v=20260527">
-    <link rel="stylesheet" href="styles/ui-kit.css?v=20260527">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="stylesheet" href="../styles/shared.css?v=20260527">
+    <link rel="stylesheet" href="../styles/ui-kit.css?v=20260527">
     <style>
         /* ══════════════════════════════════════════
            poemas.html — Poesía como Método
@@ -268,15 +268,15 @@
 
     <!-- ═══ NAV ═══ -->
     <nav class="po-nav" aria-label="Navegación principal">
-        <a href="index.html" class="po-nav-logo">
+        <a href="../index.html" class="po-nav-logo">
             <span aria-hidden="true">⊘</span>
             Contra-Archivo
             <span class="po-nav-badge">Poesía</span>
         </a>
         <div class="po-nav-links">
-            <a href="index.html">Inicio</a>
-            <a href="buscador.html">Buscador</a>
-            <a href="archivo.html">Archivo</a>
+            <a href="../index.html">Inicio</a>
+            <a href="../buscador.html">Buscador</a>
+            <a href="../archivo.html">Archivo</a>
             <a href="poemas.html" aria-current="page">Poemas</a>
         </div>
     </nav>
@@ -334,7 +334,7 @@
                     <span class="po-tag">Vigilancia</span>
                     <span class="po-tag">Autoetnografía</span>
                 </div>
-                <a href="Poemarios/trabajo-en-sura.html" class="po-btn">
+                <a href="trabajo-en-sura.html" class="po-btn">
                     Leer poema completo →
                 </a>
             </article>


### PR DESCRIPTION
## Qué cambia

La página `/Poemarios/poemas.html` tenía todas sus rutas escritas asumiendo que se servía desde la raíz, pero vive un nivel más profundo. Resultado: sin CSS, nav links con 404 y el botón «Leer poema completo» apuntaba a `/Poemarios/Poemarios/trabajo-en-sura.html`.

## Fixes

| Antes | Después |
|-------|---------|
| `styles/shared.css` | `../styles/shared.css` |
| `styles/ui-kit.css` | `../styles/ui-kit.css` |
| `manifest.json` | `../manifest.json` |
| nav `index.html` | `../index.html` |
| nav `buscador.html` | `../buscador.html` |
| nav `archivo.html` | `../archivo.html` |
| `Poemarios/trabajo-en-sura.html` | `trabajo-en-sura.html` |

## QA

- [ ] `/Poemarios/poemas.html` carga con estilos correctos
- [ ] Nav links (Inicio, Buscador, Archivo) no dan 404
- [ ] «Leer poema completo →» llega a `trabajo-en-sura.html`